### PR TITLE
[Inference] change native cpu infer to gpu disable IR infer

### DIFF
--- a/inference/inference_api_test/python_api_test/src/test_case.py
+++ b/inference/inference_api_test/python_api_test/src/test_case.py
@@ -75,12 +75,18 @@ class DeployConfig(object):
 
         if config_type == 'cpu':
             predictor_config.disable_gpu()
+        elif config_type == 'cpu_no_ir':
+            predictor_config.disable_gpu()
+            predictor_config.switch_ir_optim(False)
         elif config_type == 'mkldnn':
             predictor_config.disable_gpu()
             predictor_config.enable_mkldnn()
             predictor_config.set_cpu_math_library_num_threads(4)
         elif config_type == 'gpu':
             predictor_config.enable_use_gpu(100, 0)
+        elif config_type == 'gpu_no_ir':
+            predictor_config.enable_use_gpu(100, 0)
+            predictor_config.switch_ir_optim(False)
         elif config_type == 'lite':
             predictor_config.enable_lite_engine()
         elif config_type in trt_precision_map.keys():
@@ -94,7 +100,7 @@ class DeployConfig(object):
                 use_calib_mode=True if config_type == 'trt_int8' else False)
         else:
             raise Exception('Config type [%s] invalid!' % config_type)
-        predictor_config.switch_ir_optim(True)
+        # predictor_config.switch_ir_optim(True)
         predictor_config.switch_specify_input_names(True)
         predictor_config.enable_memory_optim()
         predictor_config.switch_use_feed_fetch_ops(False)

--- a/inference/inference_api_test/python_api_test/tests/test_inference_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/test_inference_trt_fp32.py
@@ -79,9 +79,9 @@ class TestModelInferenceTrtFp32(object):
         res, ave_time = AnalysisPredictor.analysis_predict(data_path)
         logger.info(ave_time)
 
-        NativePredictor = Predictor(
-            model_path, predictor_mode="Native", config_type="cpu")
-        exp, ave_time = NativePredictor.native_predict(data_path)
+        NoIrPredictor = Predictor(
+            model_path, predictor_mode="Analysis", config_type="gpu_no_ir")
+        exp, ave_time = NoIrPredictor.analysis_predict(data_path)
         logger.info(ave_time)
 
         nose.tools.assert_equal(


### PR DESCRIPTION
faster_rcnn 和 mask_rcnn 在 native gpu config下会遇到显存不足的问题，因此之前是比较的TRT预测的结果和native cpu config下的结果，但该配置预测速度比较慢。所以现在改成了 analysis gpu 但关闭IR optim预测。