### PR TITLE
[inferece] add paddle-inference performance demo

### DIFF
--- a/inference/inference_perf_demo/infer_perf_demo.cc
+++ b/inference/inference_perf_demo/infer_perf_demo.cc
@@ -1,0 +1,171 @@
+// Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <numeric>
+#include <iostream>
+#include <memory>
+#include <chrono>
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+
+#include "paddle/include/paddle_inference_api.h"
+
+DEFINE_string(model_path, "./mobilenetv1", "Directory of the inference model.");
+DEFINE_string(model_name, "mobilenetv1", "name of model");
+DEFINE_string(model_type, "static", "model generate type");
+
+DEFINE_bool(use_gpu, false, "use_gpu or not");
+DEFINE_bool(use_trt, false, "use trt or not");
+DEFINE_bool(use_mkldnn, false, "use mkldnn or not");
+
+DEFINE_int32(thread_num, 1, "thread_num");
+DEFINE_int32(batch_size, 1, "batch_size");
+DEFINE_int32(warmup_times, 10, "warmup");
+DEFINE_int32(repeats, 1000, "repeats");
+
+
+class Timer {
+// Timer, count in ms
+  public:
+      Timer() {
+          reset();
+      }
+      void start() {
+          start_t = std::chrono::high_resolution_clock::now();
+      }
+      void stop() {
+          auto end_t = std::chrono::high_resolution_clock::now();
+          typedef std::chrono::microseconds ms;
+          auto diff = end_t - start_t;
+          ms counter = std::chrono::duration_cast<ms>(diff);
+          total_time += counter.count();
+      }
+      void reset() {
+          total_time = 0.;
+      }
+      double report() {
+          return total_time / 1000.0;
+      }
+  private:
+      double total_time;
+      std::chrono::high_resolution_clock::time_point start_t;
+};
+
+
+namespace paddle_infer {
+
+void PrepareConfig(Config *config) {
+  // prepare Paddle-Inference Config
+  config->SetModel(FLAGS_model_path + "/__model__",
+                   FLAGS_model_path + "/__params__");
+  if (FLAGS_use_gpu){
+    config->EnableUseGpu(100, 0);
+    if (FLAGS_use_trt) {
+      config->EnableTensorRtEngine();
+    }
+  }
+  else {
+    config->DisableGpu();
+    if (FLAGS_use_mkldnn) {
+      config->EnableMKLDNN();
+      LOG(INFO) << "mkldnn enabled";
+    }
+  }
+}
+
+double Inference(Predictor* pred, int tid) {
+  int channels = 3;
+  int height = 224;
+  int width = 224;
+  int batch_size = FLAGS_batch_size;
+  int input_num = channels * height * width * batch_size;
+
+  // prepare inputs
+  std::vector<float> in_data(input_num);
+  for (int i=0; i < input_num; ++i) {
+    in_data[i] = i % 10 * 0.1;
+  }
+
+  // set inputs
+  auto in_names = pred->GetInputNames();
+  auto input_t = pred->GetInputHandle(in_names[0]);
+  input_t->Reshape({batch_size, channels, height, width});
+  input_t->CopyFromCpu(in_data.data());
+
+  // warm-up
+  for (size_t i = 0; i < FLAGS_warmup_times; ++i) {
+    pred->Run();
+  }
+
+  Timer pred_timer; // init prediction timer
+  int out_num = 0;
+  std::vector<float> out_data;
+
+  // main prediction process
+  pred_timer.start(); // start timer
+  for (size_t i = 0; i < FLAGS_repeats; ++i) {
+    pred->Run();
+    auto out_names = pred->GetOutputNames();
+    auto output_t = pred->GetOutputHandle(out_names[0]);
+
+    std::vector<int> output_shape = output_t->shape();
+    // retrive date to output vector
+    out_num = std::accumulate(output_shape.begin(), output_shape.end(), 1, std::multiplies<int>());
+    out_data.resize(out_num);
+    output_t->CopyToCpu(out_data.data());
+  }
+  pred_timer.stop(); // stop timer
+
+  return pred_timer.report();
+}
+
+void RunDemo() {
+  Config config;
+  PrepareConfig(&config);
+
+  services::PredictorPool pred_pool(config, FLAGS_thread_num);
+
+  auto total_time = Inference(pred_pool.Retrive(0), 0);
+
+  LOG(INFO) << "----------------------- Model info ----------------------";
+  LOG(INFO) << "Model name: " << FLAGS_model_name << ", Model type: " << FLAGS_model_type;
+  LOG(INFO) << "----------------------- Data info -----------------------";
+  LOG(INFO) << "Batch size: " << FLAGS_batch_size << ", Num of samples: " << FLAGS_repeats;
+  LOG(INFO) << "----------------------- Conf info -----------------------";
+  LOG(INFO) << "device: " << (config.use_gpu() ? "gpu" : "cpu") << ", thread num: " << 2 << ", ir_optim: " << (config.ir_optim() ? "true" : "false");
+  if (FLAGS_use_gpu){
+    if (FLAGS_use_trt) {
+      LOG(INFO) << "enable_tensorrt: " << (config.tensorrt_engine_enabled() ? "true" : "false");
+    }
+  }
+  else {
+    LOG(INFO) << "cpu_math_library_num_threads: " << config.cpu_math_library_num_threads();
+    if (FLAGS_use_mkldnn) {
+      LOG(INFO) << "enable_mkldnn: " << (config.mkldnn_enabled() ? "true" : "false");
+    }
+  }
+  LOG(INFO) << "----------------------- Perf info -----------------------";
+  LOG(INFO) << "Average latency(ms): " << total_time / static_cast<float>(FLAGS_repeats) << ", QPS: " << (FLAGS_repeats * FLAGS_batch_size)/ (total_time/1000) ;
+}
+
+} // namespace paddle_infer
+
+
+int main(int argc, char**argv) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  paddle_infer::RunDemo();
+  return 0;
+}
+

--- a/inference/inference_perf_demo/infer_perf_demo.py
+++ b/inference/inference_perf_demo/infer_perf_demo.py
@@ -1,3 +1,16 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import argparse
 import time
@@ -7,8 +20,8 @@ import paddle.fluid.inference as paddle_infer
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--model_name", type=str, help="model filename")
-    parser.add_argument("--model_type", type=str, help="model filename")
+    parser.add_argument("--model_name", type=str, help="model name")
+    parser.add_argument("--model_type", type=str, help="model generate type")
     parser.add_argument("--model_file", type=str, help="model filename")
     parser.add_argument("--params_file", type=str, help="parameter filename")
 
@@ -20,22 +33,24 @@ def parse_args():
     parser.add_argument("--warmup_times", type=int, default=0, help="warmup")
     parser.add_argument("--repeats", type=int, default=1, help="repeats")
     parser.add_argument(
-        "--cpu_math_library_num_threads", type=int, default=1, help="math_thread_num")
-
+        "--cpu_math_library_num_threads",
+        type=int,
+        default=1,
+        help="math_thread_num")
 
     return parser.parse_args()
 
 
 def prepare_config(args):
-    config = paddle_infer.Config(args.model_file, 
-                                 args.params_file)
+    config = paddle_infer.Config(args.model_file, args.params_file)
     if (args.use_gpu):
         config.enable_use_gpu(100, 0)
         if (args.use_trt):
             config.enable_tensorrt_engine()
     else:
         config.disable_gpu()
-        config.set_cpu_math_library_num_threads(args.cpu_math_library_num_threads)
+        config.set_cpu_math_library_num_threads(
+            args.cpu_math_library_num_threads)
         if (args.use_mkldnn):
             config.enable_mkldnn()
     return config
@@ -60,7 +75,7 @@ def Inference(args, predictor):
     time2 = time.time()
     output_data = output_hanlde.copy_to_cpu()
 
-    total_inference_cost = (time2 - time1) * 1000 # 总时延，ms
+    total_inference_cost = (time2 - time1) * 1000  # total latency, ms
 
     return total_inference_cost
 
@@ -73,23 +88,27 @@ def run_demo():
     total_time = Inference(args, predictor)
 
     print("----------------------- Model info ----------------------")
-    print("Model name: {}, Model type: {}".format(args.model_name, args.model_type))
+    print("Model name: {}, Model type: {}".format(args.model_name,
+                                                  args.model_type))
     print("----------------------- Data info -----------------------")
-    print("Batch size: {}, Num of samples: {}".format(args.batch_size, args.repeats))
+    print("Batch size: {}, Num of samples: {}".format(args.batch_size,
+                                                      args.repeats))
     print("----------------------- Conf info -----------------------")
-    print("device: {}, ir_optim: {}".format("gpu" if config.use_gpu() else "cpu",
-                                            config.ir_optim()))
+    print("device: {}, ir_optim: {}".format("gpu" if config.use_gpu() else
+                                            "cpu", config.ir_optim()))
     if (args.use_gpu):
         if (args.use_trt):
-            print("enable_tensorrt: {}".format(config.tensorrt_engine_enabled()))
+            print("enable_tensorrt: {}".format(config.tensorrt_engine_enabled(
+            )))
     else:
-        print("cpu_math_library_num_threads: {}".format(config.cpu_math_library_num_threads()))
+        print("cpu_math_library_num_threads: {}".format(
+            config.cpu_math_library_num_threads()))
         if (args.use_mkldnn):
             print("enable_mkldnn: {}".format(config.mkldnn_enabled()))
     print("----------------------- Perf info -----------------------")
-    print("Average latency(ms): {}, QPS: {}".format(total_time/args.repeats, (args.repeats * args.batch_size) / (total_time/1000)))
+    print("Average latency(ms): {}, QPS: {}".format(total_time / args.repeats, (
+        args.repeats * args.batch_size) / (total_time / 1000)))
 
 
 if __name__ == "__main__":
     run_demo()
-

--- a/inference/inference_perf_demo/infer_perf_demo.py
+++ b/inference/inference_perf_demo/infer_perf_demo.py
@@ -1,0 +1,95 @@
+
+import argparse
+import time
+import numpy as np
+import paddle.fluid.inference as paddle_infer
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model_name", type=str, help="model filename")
+    parser.add_argument("--model_type", type=str, help="model filename")
+    parser.add_argument("--model_file", type=str, help="model filename")
+    parser.add_argument("--params_file", type=str, help="parameter filename")
+
+    parser.add_argument("--use_gpu", dest="use_gpu", action='store_true')
+    parser.add_argument("--use_trt", dest="use_trt", action='store_true')
+    parser.add_argument("--use_mkldnn", dest="use_mkldnn", action='store_true')
+
+    parser.add_argument("--batch_size", type=int, default=1, help="batch size")
+    parser.add_argument("--warmup_times", type=int, default=0, help="warmup")
+    parser.add_argument("--repeats", type=int, default=1, help="repeats")
+    parser.add_argument(
+        "--cpu_math_library_num_threads", type=int, default=1, help="math_thread_num")
+
+
+    return parser.parse_args()
+
+
+def prepare_config(args):
+    config = paddle_infer.Config(args.model_file, 
+                                 args.params_file)
+    if (args.use_gpu):
+        config.enable_use_gpu(100, 0)
+        if (args.use_trt):
+            config.enable_tensorrt_engine()
+    else:
+        config.disable_gpu()
+        config.set_cpu_math_library_num_threads(args.cpu_math_library_num_threads)
+        if (args.use_mkldnn):
+            config.enable_mkldnn()
+    return config
+
+
+def Inference(args, predictor):
+    input_names = predictor.get_input_names()
+    input_handle = predictor.get_input_handle(input_names[0])
+
+    fake_input = np.ones((args.batch_size, 3, 224, 224)).astype("float32")
+    input_handle.reshape([args.batch_size, 3, 224, 224])
+    input_handle.copy_from_cpu(fake_input)
+
+    for i in range(args.warmup_times):
+        predictor.run()
+
+    time1 = time.time()
+    for i in range(args.repeats):
+        predictor.run()
+        output_names = predictor.get_output_names()
+        output_hanlde = predictor.get_output_handle(output_names[0])
+    time2 = time.time()
+    output_data = output_hanlde.copy_to_cpu()
+
+    total_inference_cost = (time2 - time1) * 1000 # 总时延，ms
+
+    return total_inference_cost
+
+
+def run_demo():
+    args = parse_args()
+    config = prepare_config(args)
+    predictor_pool = paddle_infer.PredictorPool(config, 1)
+    predictor = predictor_pool.retrive(0)
+    total_time = Inference(args, predictor)
+
+    print("----------------------- Model info ----------------------")
+    print("Model name: {}, Model type: {}".format(args.model_name, args.model_type))
+    print("----------------------- Data info -----------------------")
+    print("Batch size: {}, Num of samples: {}".format(args.batch_size, args.repeats))
+    print("----------------------- Conf info -----------------------")
+    print("device: {}, ir_optim: {}".format("gpu" if config.use_gpu() else "cpu",
+                                            config.ir_optim()))
+    if (args.use_gpu):
+        if (args.use_trt):
+            print("enable_tensorrt: {}".format(config.tensorrt_engine_enabled()))
+    else:
+        print("cpu_math_library_num_threads: {}".format(config.cpu_math_library_num_threads()))
+        if (args.use_mkldnn):
+            print("enable_mkldnn: {}".format(config.mkldnn_enabled()))
+    print("----------------------- Perf info -----------------------")
+    print("Average latency(ms): {}, QPS: {}".format(total_time/args.repeats, (args.repeats * args.batch_size) / (total_time/1000)))
+
+
+if __name__ == "__main__":
+    run_demo()
+


### PR DESCRIPTION
C++ cpu mkldnn sample log
```shell
I1118 11:07:46.957657  4122 infer_perf_demo.cc:129] ----------------------- Model info ----------------------
I1118 11:07:46.957840  4122 infer_perf_demo.cc:130] Model name: mobilenetv1, Model type: dy2static
I1118 11:07:46.957857  4122 infer_perf_demo.cc:131] ----------------------- Data info -----------------------
I1118 11:07:46.957867  4122 infer_perf_demo.cc:132] Batch size: 1, Num of samples: 10
I1118 11:07:46.957885  4122 infer_perf_demo.cc:133] ----------------------- Conf info -----------------------
I1118 11:07:46.957901  4122 infer_perf_demo.cc:134] device: cpu, thread num: 2, ir_optim: true
I1118 11:07:46.957913  4122 infer_perf_demo.cc:141] cpu_math_library_num_threads: 1
I1118 11:07:46.957926  4122 infer_perf_demo.cc:143] enable_mkldnn: true
I1118 11:07:46.957940  4122 infer_perf_demo.cc:146] ----------------------- Perf info -----------------------
I1118 11:07:46.957952  4122 infer_perf_demo.cc:147] Average latency(ms): 22.1658, QPS: 45.1145
```


python cpu mkldnn sample log
```shell
----------------------- Model info ----------------------
Model name: mobilenetv1, Model type: static
----------------------- Data info -----------------------
Batch size: 1, Num of samples: 1
----------------------- Conf info -----------------------
device: cpu, ir_optim: True
cpu_math_library_num_threads: 5
enable_mkldnn: True
----------------------- Perf info -----------------------
Average latency(ms): 26.057958602905273, QPS: 38.375991582414564
```
