### PR TITLE
upload cpu mkldnn linux benchmark scripts

### DIFF
--- a/inference/inference_benchmark/cc/Paddle/README_mkl.md
+++ b/inference/inference_benchmark/cc/Paddle/README_mkl.md
@@ -1,0 +1,54 @@
+# Paddle-Inference CPU Benchmark
+
+## quick start
+
+### compile inference demo
+shell scripts only support linux platfrom right now.
+windows bat scripts will be added later
+```shell
+DEMO_NAME="all"   # name of test demo, it can be clas_benchmark, rcnn_benchmark
+WITH_MKL=ON       # whether to use MKL
+WITH_GPU=OFF      # whether to use GPU
+USE_TENSORRT=OFF  # whether to use TENSORRT
+LIB_DIR="/workspace/paddle_inference_install_dir" # path of cpp inference lib
+
+bash compile.sh ${DEMO_NAME} ${WITH_MKL} ${WITH_GPU} ${USE_TENSORRT} ${LIB_DIR}
+```
+
+### run batch test scripts
+`bin` directory has starting scripts, resources monitor scripts and log parser.
+```shell
+# Python scripts
+py_mem.py  # monitor inference bin（GPU+CPU），only support linux x86 currently
+py_parse_log.py # parse inference logs and covert to excel
+
+# Shell scripts
+run_models_benchmark.sh # main scripts, execute will download models if it not exist
+run_clas_mkl_benchmark.sh
+run_det_mkl_benchmark.sh
+```
+
+### whole process
+```shell
+# 1. download inference-lib or compile from source codes
+
+# 2. download test codes
+git clone https://github.com/PaddlePaddle/continuous_integration.git
+
+# 3. compile test codes
+cd continuous_integration/inference/inference_benchmark/cc/Paddle
+bash compile.sh all ON OFF OFF /path/of/inference-lib
+
+# 4. prepare python third-party lib
+python3.7 -m pip install py3nvml;  # monitor gpu
+python3.7 -m pip install cup;      # monitor cpu
+python3.7 -m pip install pandas;   # process data
+python3.7 -m pip install openpyxl; # process data to excel
+
+
+# 5. start benchmark tests
+bash bin/run_models_benchmark.sh "static" "cpu"
+
+# 6. convert data to excel
+python3.7 bin/py_parse_log.py --log_path=./log --output_name=benchmark_mkl_excel.xlsx
+```

--- a/inference/inference_benchmark/cc/Paddle/bin/run_clas_mkl_benchmark.sh
+++ b/inference/inference_benchmark/cc/Paddle/bin/run_clas_mkl_benchmark.sh
@@ -1,0 +1,207 @@
+#!/bin/bash
+export RED='\033[0;31m' # red color
+export NC='\033[0m' # no color
+export YELLOW='\033[33m' # yellow color
+
+test_cpu(){
+    exe_bin=$1 # ./build/clas_benchmark
+    model_name=$2
+    model_path=$3
+    params_path=$4
+
+    image_shape="3,224,224"
+    if [ $# -ge 5 ]; then
+        image_shape=$5
+    fi
+    printf "${YELLOW} ${model_name} input image_shape = ${image_shape} ${NC} \n";
+    use_gpu=false;
+
+    for batch_size in "1" "2" "4"
+    do
+        echo " "
+        printf "start ${YELLOW} ${model_name}, use_gpu: ${use_gpu}, batch_size: ${batch_size}${NC}\n"
+
+        log_file="${LOG_ROOT}/${model_name}_cpu_bz${batch_size}_infer.log"
+        $OUTPUT_BIN/${exe_bin} --model_name=${model_name} \
+            --model_path=${model_path} \
+            --params_path=${params_path} \
+            --image_shape=${image_shape} \
+            --batch_size=${batch_size} \
+            --model_type=${MODEL_TYPE} \
+            --repeats=500 \
+            --use_gpu=${use_gpu} >> ${log_file} 2>&1 | python3.7 ${CASE_ROOT}/py_mem.py "$OUTPUT_BIN/${exe_bin}" >> ${log_file} 2>&1
+
+        printf "finish ${RED} ${model_name}, use_gpu: ${use_gpu}, batch_size: ${batch_size}${NC}\n"
+        echo " "
+    done                               
+}
+
+
+test_mkldnn(){
+    exe_bin=$1 # ./build/clas_benchmark
+    model_name=$2
+    model_path=$3
+    params_path=$4
+
+    image_shape="3,224,224"
+    if [ $# -ge 5 ]; then
+        image_shape=$5
+    fi
+    printf "${YELLOW} ${model_name} input image_shape = ${image_shape} ${NC} \n";
+    use_gpu=false;
+    use_mkldnn=true;
+
+    for batch_size in "1" "2" "4"
+    do
+        for cpu_math_library_num_threads in "1" "2" "4"
+        do
+            echo " "
+            printf "start ${YELLOW} ${model_name}, use_mkldnn: ${use_mkldnn}, cpu_math_library_num_threads: ${cpu_math_library_num_threads}, batch_size: ${batch_size}${NC}\n"
+
+            log_file="${LOG_ROOT}/${model_name}_mkldnn_${cpu_math_library_num_threads}_bz${batch_size}_infer.log"
+            $OUTPUT_BIN/${exe_bin} --model_name=${model_name} \
+                --model_path=${model_path} \
+                --params_path=${params_path} \
+                --image_shape=${image_shape} \
+                --batch_size=${batch_size} \
+                --use_gpu=${use_gpu} \
+                --repeats=500 \
+                --model_type=${MODEL_TYPE} \
+                --cpu_math_library_num_threads=${cpu_math_library_num_threads} \
+                --use_mkldnn_=${use_mkldnn} >> ${log_file} 2>&1 | python3.7 ${CASE_ROOT}/py_mem.py "$OUTPUT_BIN/${exe_bin}" >> ${log_file} 2>&1
+
+            printf "finish ${RED} ${model_name}, use_mkldnn: ${use_mkldnn}, cpu_math_library_num_threads: ${cpu_math_library_num_threads}, batch_size: ${batch_size}${NC}\n"
+            echo " "
+        done
+    done                               
+}
+
+main(){
+    printf "${YELLOW} ==== start benchmark ==== ${NC} \n"
+    model_root=$1
+
+    class_model="AlexNet \
+                 DarkNet53 \
+                 DenseNet121 \
+                 DPN68 \
+                 EfficientNetB0 \
+                 GhostNet_x1_3 \
+                 GoogLeNet \
+                 HRNet_W18_C \
+                 InceptionV4 \
+                 MobileNetV1 \
+                 MobileNetV2 \
+                 MobileNetV3_large_x1_0 \
+                 RegNetX_4GF \
+                 Res2Net50_26w_4s \
+                 ResNeSt50_fast_1s1x64d \
+                 ResNet50 \
+                 ResNet50_vd \
+                 SE_ResNeXt50_vd_32x4d \
+                 ShuffleNetV2 \
+                 SqueezeNet1_0 \
+                 VGG11 \
+                 Xception41"
+    
+    for tests in ${class_model}
+    do
+        test_cpu "clas_benchmark" "${tests}" \
+                 ${model_root}/${tests}/__model__ \
+                 ${model_root}/${tests}/params
+    
+        test_mkldnn "clas_benchmark" "${tests}" \
+                 ${model_root}/${tests}/__model__ \
+                 ${model_root}/${tests}/params
+    done
+
+    if [ "${MODEL_TYPE}" == "static" ]; then
+        # ssdlite_mobilenet_v3_large
+        model_case="ssdlite_mobilenet_v3_large"
+        test_cpu "clas_benchmark" "${model_case}" \
+                "${DATA_ROOT}/PaddleDetection/infer_static/${model_case}/__model__" \
+                "${DATA_ROOT}/PaddleDetection/infer_static/${model_case}/__params__" \
+                "3,320,320"
+
+        test_mkldnn "clas_benchmark" "${model_case}" \
+                "${DATA_ROOT}/PaddleDetection/infer_static/${model_case}/__model__" \
+                "${DATA_ROOT}/PaddleDetection/infer_static/${model_case}/__params__" \
+                "3,320,320"
+        
+        # ssd_mobilenet_v1_voc
+        model_case="ssd_mobilenet_v1_voc"
+        test_cpu "clas_benchmark" "${model_case}" \
+                "${DATA_ROOT}/PaddleDetection/infer_static/${model_case}/__model__" \
+                "${DATA_ROOT}/PaddleDetection/infer_static/${model_case}/__params__" \
+                "3,300,300"
+
+        test_mkldnn "clas_benchmark" "${model_case}" \
+                "${DATA_ROOT}/PaddleDetection/infer_static/${model_case}/__model__" \
+                "${DATA_ROOT}/PaddleDetection/infer_static/${model_case}/__params__" \
+                "3,300,300"
+        
+        seg_model="deeplabv3p \
+                fastscnn \
+                hrnet \
+                icnet \
+                pspnet \
+                unet"
+
+        for tests in ${seg_model}
+        do
+            test_cpu "clas_benchmark" "${tests}" \
+                    ${DATA_ROOT}/PaddleSeg/infer_static/${tests}/__model__ \
+                    ${DATA_ROOT}/PaddleSeg/infer_static/${tests}/__params__ \
+                    "3,512,512"
+        
+            test_mkldnn "clas_benchmark" "${tests}" \
+                    ${DATA_ROOT}/PaddleSeg/infer_static/${tests}/__model__ \
+                    ${DATA_ROOT}/PaddleSeg/infer_static/${tests}/__params__ \
+                    "3,512,512"
+        done
+
+        # ch_ppocr_mobile_v1.1_cls_infer
+        model_case="ch_ppocr_mobile_v1.1_cls_infer"
+        test_cpu "clas_benchmark" "${model_case}" \
+                "${DATA_ROOT}/PaddleOCR/${model_case}/model" \
+                "${DATA_ROOT}/PaddleOCR/${model_case}/params" \
+                "3,48,192"
+
+        test_mkldnn "clas_benchmark" "${model_case}" \
+                "${DATA_ROOT}/PaddleOCR/${model_case}/model" \
+                "${DATA_ROOT}/PaddleOCR/${model_case}/params" \
+                "3,48,192"
+        
+        # ch_ppocr_mobile_v1.1_det_infer
+        model_case="ch_ppocr_mobile_v1.1_det_infer"
+        test_cpu "clas_benchmark" "${model_case}" \
+                "${DATA_ROOT}/PaddleOCR/${model_case}/model" \
+                "${DATA_ROOT}/PaddleOCR/${model_case}/params" \
+                "3,640,640"
+
+        test_mkldnn "clas_benchmark" "${model_case}" \
+                "${DATA_ROOT}/PaddleOCR/${model_case}/model" \
+                "${DATA_ROOT}/PaddleOCR/${model_case}/params" \
+                "3,640,640"
+        
+        # ch_ppocr_mobile_v1.1_rec_infer
+        model_case="ch_ppocr_mobile_v1.1_rec_infer"
+        test_cpu "clas_benchmark" "${model_case}" \
+                "${DATA_ROOT}/PaddleOCR/${model_case}/model" \
+                "${DATA_ROOT}/PaddleOCR/${model_case}/params" \
+                "3,32,320"
+
+        test_mkldnn "clas_benchmark" "${model_case}" \
+                "${DATA_ROOT}/PaddleOCR/${model_case}/model" \
+                "${DATA_ROOT}/PaddleOCR/${model_case}/params" \
+                "3,32,320" "10"
+    fi
+
+    printf "${YELLOW} ==== finish benchmark ==== ${NC} \n"
+}
+
+model_root=${DATA_ROOT}/PaddleClas/infer_static
+if [ $# -ge 1 ]; then
+    model_root=$1
+fi
+
+main ${model_root}

--- a/inference/inference_benchmark/cc/Paddle/bin/run_det_mkl_benchmark.sh
+++ b/inference/inference_benchmark/cc/Paddle/bin/run_det_mkl_benchmark.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+export RED='\033[0;31m' # red color
+export NC='\033[0m' # no color
+export YELLOW='\033[33m' # yellow color
+
+test_cpu(){
+    exe_bin=$1 # ./build/clas_benchmark
+    model_name=$2
+    model_path=$3
+    params_path=$4
+
+    image_shape="3,224,224"
+    if [ $# -ge 5 ]; then
+        image_shape=$5
+    fi
+    printf "${YELLOW} ${model_name} input image_shape = ${image_shape} ${NC} \n";
+    use_gpu=false;
+
+    for batch_size in "1" "2" "4"
+    do
+        echo " "
+        printf "start ${YELLOW} ${model_name}, use_gpu: ${use_gpu}, batch_size: ${batch_size}${NC}\n"
+
+        log_file="${LOG_ROOT}/${model_name}_cpu_bz${batch_size}_infer.log"
+        $OUTPUT_BIN/${exe_bin} --model_name=${model_name} \
+            --model_path=${model_path} \
+            --params_path=${params_path} \
+            --image_shape=${image_shape} \
+            --batch_size=${batch_size} \
+            --model_type=${MODEL_TYPE} \
+            --repeats=500 \
+            --use_gpu=${use_gpu} >> ${log_file} 2>&1 | python3.7 ${CASE_ROOT}/py_mem.py "$OUTPUT_BIN/${exe_bin}" >> ${log_file} 2>&1
+
+        printf "finish ${RED} ${model_name}, use_gpu: ${use_gpu}, batch_size: ${batch_size}${NC}\n"
+        echo " "
+    done                               
+}
+
+
+test_mkldnn(){
+    exe_bin=$1 # ./build/clas_benchmark
+    model_name=$2
+    model_path=$3
+    params_path=$4
+
+    image_shape="3,224,224"
+    if [ $# -ge 5 ]; then
+        image_shape=$5
+    fi
+    printf "${YELLOW} ${model_name} input image_shape = ${image_shape} ${NC} \n";
+    use_gpu=false;
+    use_mkldnn=true;
+
+    for batch_size in "1" "2" "4"
+    do
+        for cpu_math_library_num_threads in "1" "2" "4"
+        do
+            echo " "
+            printf "start ${YELLOW} ${model_name}, use_mkldnn: ${use_mkldnn}, cpu_math_library_num_threads: ${cpu_math_library_num_threads}, batch_size: ${batch_size}${NC}\n"
+
+            log_file="${LOG_ROOT}/${model_name}_mkldnn_${cpu_math_library_num_threads}_bz${batch_size}_infer.log"
+            $OUTPUT_BIN/${exe_bin} --model_name=${model_name} \
+                --model_path=${model_path} \
+                --params_path=${params_path} \
+                --image_shape=${image_shape} \
+                --batch_size=${batch_size} \
+                --use_gpu=${use_gpu} \
+                --repeats=500 \
+                --model_type=${MODEL_TYPE} \
+                --cpu_math_library_num_threads=${cpu_math_library_num_threads} \
+                --use_mkldnn_=${use_mkldnn} >> ${log_file} 2>&1 | python3.7 ${CASE_ROOT}/py_mem.py "$OUTPUT_BIN/${exe_bin}" >> ${log_file} 2>&1
+
+            printf "finish ${RED} ${model_name}, use_mkldnn: ${use_mkldnn}, cpu_math_library_num_threads: ${cpu_math_library_num_threads}, batch_size: ${batch_size}${NC}\n"
+            echo " "
+        done
+    done                               
+}
+
+main(){
+    printf "${YELLOW} ==== start benchmark ==== ${NC} \n"
+    model_root=$1
+
+    rcnn_model="mask_rcnn_r50_1x \
+                faster_rcnn_r50_1x \
+                faster_rcnn_dcn_r50_vd_fpn_3x_server_side"
+                
+    for tests in ${rcnn_model}
+    do
+        test_cpu "rcnn_benchmark" "${tests}" \
+                ${model_root}/${tests}/__model__ \
+                ${model_root}/${tests}/__params__ \
+                "3,640,640"
+
+        test_mkldnn "rcnn_benchmark" "${tests}" \
+                 ${model_root}/${tests}/__model__ \
+                 ${model_root}/${tests}/__params__ \
+                 "3,640,640" "40"
+    done
+
+    yolo_model="ppyolo_mobilenet_v3_large \
+                yolov3_darknet \
+                yolov3_mobilenet_v3 \
+                yolov3_r50vd_dcn \
+                yolov4_cspdarknet"
+                
+    for tests in ${yolo_model}
+    do
+        test_cpu "yolo_benchmark" "${tests}" \
+                 ${model_root}/${tests}/__model__ \
+                 ${model_root}/${tests}/__params__ \
+                 "3,608,608"
+    
+        test_mkldnn "yolo_benchmark" "${tests}" \
+                 ${model_root}/${tests}/__model__ \
+                 ${model_root}/${tests}/__params__ \
+                 "3,608,608"
+    done
+
+    printf "${YELLOW} ==== finish benchmark ==== ${NC} \n"
+}
+
+model_root=${DATA_ROOT}/PaddleDetection/infer_static
+if [ $# -ge 1 ]; then
+    model_root=$1
+fi
+
+main ${model_root}

--- a/inference/inference_benchmark/cc/Paddle/bin/run_models_benchmark.sh
+++ b/inference/inference_benchmark/cc/Paddle/bin/run_models_benchmark.sh
@@ -11,12 +11,18 @@ export CASE_ROOT=$ROOT/bin
 export LOG_ROOT=$ROOT/log
 export gpu_type=`nvidia-smi -q | grep "Product Name" | head -n 1 | awk '{print $NF}'`
 
+# test model type
 model_type="static"
 if [ $# -ge 1 ]; then
     model_type=$1
 fi
 export MODEL_TYPE=${model_type}
 
+# test run-time device
+device_type="gpu"
+if [ $# -ge 2 ]; then
+    device_type=$2
+fi
 
 mkdir -p $DATA_ROOT
 cd $DATA_ROOT
@@ -51,10 +57,15 @@ mkdir -p $LOG_ROOT
 echo "==== run ${MODEL_TYPE} model benchmark ===="
 
 if [ "${MODEL_TYPE}" == "static" ]; then
-    bash $CASE_ROOT/run_clas_gpu_trt_benchmark.sh "${DATA_ROOT}/PaddleClas/infer_static"
-    bash $CASE_ROOT/run_det_gpu_trt_benchmark.sh "${DATA_ROOT}/PaddleDetection/infer_static"
-    bash $CASE_ROOT/run_clas_int8_benchmark.sh "${DATA_ROOT}/PaddleClas/infer_static"
-    bash $CASE_ROOT/run_det_int8_benchmark.sh "${DATA_ROOT}/PaddleDetection/infer_static"
+    if [ "${device_type}" == "gpu" ]; then
+        bash $CASE_ROOT/run_clas_gpu_trt_benchmark.sh "${DATA_ROOT}/PaddleClas/infer_static"
+        bash $CASE_ROOT/run_det_gpu_trt_benchmark.sh "${DATA_ROOT}/PaddleDetection/infer_static"
+        bash $CASE_ROOT/run_clas_int8_benchmark.sh "${DATA_ROOT}/PaddleClas/infer_static"
+        bash $CASE_ROOT/run_det_int8_benchmark.sh "${DATA_ROOT}/PaddleDetection/infer_static"
+    elif [ "${device_type}" == "cpu" ]; then 
+        bash $CASE_ROOT/run_clas_mkl_benchmark.sh "${DATA_ROOT}/PaddleClas/infer_static"
+        # bash $CASE_ROOT/run_det_mkl_benchmark.sh "${DATA_ROOT}/PaddleDetection/infer_static"  # very slow
+    fi
 elif [ "${MODEL_TYPE}" == "dy2static" ]; then
     bash $CASE_ROOT/run_clas_gpu_trt_benchmark.sh "${DATA_ROOT}/PaddleClas/infer_dygraph"
     # bash $CASE_ROOT/run_dy2staic_det_gpu_trt_benchmark.sh


### PR DESCRIPTION
1. add cpu mkldnn linux benchmark scripts
2. Test scripts contain analysis cpu performance, mkldnn performance, different `cpu_math_library_num_threads` performance. 


reproduce method is as follow 
```shell
# 1. download inference-lib or compile from source codes

# 2. download test codes
git clone https://github.com/PaddlePaddle/continuous_integration.git

# 3. compile test codes
cd continuous_integration/inference/inference_benchmark/cc/Paddle
bash compile.sh all ON OFF OFF /path/of/inference-lib

# 4. prepare python third-party lib
python3.7 -m pip install py3nvml;  # monitor gpu
python3.7 -m pip install cup;          # monitor cpu
python3.7 -m pip install pandas;    # process data
python3.7 -m pip install openpyxl; # process data to excel

# 5. start benchmark tests
bash bin/run_models_benchmark.sh "static" "cpu"

# 6. convert data to excel
python3.7 bin/py_parse_log.py --log_path=./log --output_name=benchmark_mkl_excel.xlsx
```