### PR TITLE
add model upload scripts

### DIFF
--- a/tipc/tipc.sh
+++ b/tipc/tipc.sh
@@ -5,6 +5,7 @@ set -ex
 #repo_list="PaddleOCR PaddleClas PaddleSeg PaddleNLP PaddleDetection PaddleRec DeepSpeech"
 
 REPO=$1
+model_path_in_docker=$2
 DOCKER_IMAGE=registry.baidubce.com/paddlepaddle/paddle:latest-dev-cuda10.1-cudnn7-gcc82
 DOCKER_NAME=paddle_whole_chain_test
 #COMPILE_PATH=https://paddle-qa.bj.bcebos.com/paddle-pipeline/Master_GpuAll_LinuxUbuntu_Gcc82_Cuda10.1_Trton_Py37_Compile_H_DISTRIBUTE/latest/paddlepaddle_gpu-0.0.0-cp37-cp37m-linux_x86_64.whl 
@@ -50,7 +51,7 @@ mkdir -p run_env
 ln -s /usr/local/bin/python3.7 run_env/python
 ln -s /usr/local/bin/pip3.7 run_env/pip
 export PATH=/workspace/run_env:/usr/local/gcc-8.2/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-python -m pip install --retries 50 --upgrade pip
+python -m pip install --retries 50 --upgrade pip -i https://mirror.baidu.com/pypi/simple
 if [[ $REPO == "PaddleSeg" ]]; then
     python -m pip install --retries 50 paddleseg
     python -m pip install --retries 50 scikit-image
@@ -88,6 +89,10 @@ else
     cp ../continuous_integration/tipc/tipc_run.sh .
 fi
 sh tipc_run.sh
+if [[ ${model_path_in_docker} != "" ]]; then
+    cd /workspace
+    bash -x upload_model.sh ${REPO} "${model_path_in_docker}"
+fi
 "
 
 

--- a/tipc/upload_model.sh
+++ b/tipc/upload_model.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+REPO=$1
+model_path_in_docker=$2
+# example
+# model_path_in_docker="/workspace/PaddleNLP/tests/infer_model,transformer:/workspace/PaddleNLP/tests/test_tipc/bigru_crf/infer_model,bigru_crf"
+
+if [[ ${model_path_in_docker} == "" ]]; then
+    echo 'model_path_in_docker not passed'
+    exit 0
+fi
+
+# Push BOS
+python2 -m pip install --retries 10 pycrypto -i https://mirror.baidu.com/pypi/simple
+push_dir=$PWD
+push_file=${push_dir}/bce-python-sdk-0.8.27/BosClient.py
+if [ ! -f ${push_file} ];then
+    set +x
+    wget -q --no-proxy -O $PWD/bce_whl.tar.gz  https://paddle-docker-tar.bj.bcebos.com/home/bce_whl.tar.gz --no-check-certificate
+    set -x
+    tar xf $PWD/bce_whl.tar.gz -C ${push_dir}
+fi
+time_stamp=`date +%Y_%m_%d`
+cd "/workspace/${REPO}"
+repo_commit=`git rev-parse HEAD`
+cd -
+cd /workspace
+paddle_commit=`git rev-parse HEAD`
+cd -
+
+IFS=":"
+model_array=(${model_path_in_docker})
+
+for single_model in ${model_array[@]}
+do
+    echo ${single_model}
+    IFS=","
+    array=(${single_model})
+    model_path=${array[0]}
+    model_tar_name="${time_stamp}^${REPO}^${array[1]}^${paddle_commit}^${repo_commit}.tgz"
+    echo ${model_path}
+    echo ${model_name}
+    tar -zcvf ${model_tar_name} ${model_path}
+    python2 ${push_file} ${model_tar_name} paddle-qa/fullchain_ce_test
+done


### PR DESCRIPTION
增加TIPC任务导出预测模型后上传BOS的脚本
model_path_in_docker="model1_path,model1_name:model2_path,model2_name"
model_path_in_docker="/workspace/PaddleNLP/tests/infer_model,transformer:/workspace/PaddleNLP/tests/test_tipc/bigru_crf/infer_model,bigru_crf"
sh tipc.sh ${REPO} ${model_path_in_docker}