### PR TITLE
remove the .copy() of copy_from_cpu

### DIFF
--- a/inference/inference_api_test/python_api_test/tests/gpu/test_v1_AlexNet_gpu.py
+++ b/inference/inference_api_test/python_api_test/tests/gpu/test_v1_AlexNet_gpu.py
@@ -49,7 +49,7 @@ def inference_AlexNet(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()
@@ -62,7 +62,8 @@ def inference_AlexNet(img, model_path, params_path):
         output_data = output_tensor.copy_to_cpu()
         results.append(output_data)
     return results
-    
+
+
 @pytest.mark.p0
 def test_AlexNet():
     """
@@ -87,5 +88,3 @@ def test_AlexNet():
     # for test images class 
     # np.save("AlexNet.npy",with_lr_data[0])
     # print(np.argmax(with_lr_data[0][0]))
-
-

--- a/inference/inference_api_test/python_api_test/tests/gpu/test_v1_DPN68_gpu.py
+++ b/inference/inference_api_test/python_api_test/tests/gpu/test_v1_DPN68_gpu.py
@@ -49,7 +49,7 @@ def inference_DPN68(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/gpu/test_v1_DarkNet53_gpu.py
+++ b/inference/inference_api_test/python_api_test/tests/gpu/test_v1_DarkNet53_gpu.py
@@ -49,7 +49,7 @@ def inference_DarkNet53(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()
@@ -62,7 +62,8 @@ def inference_DarkNet53(img, model_path, params_path):
         output_data = output_tensor.copy_to_cpu()
         results.append(output_data)
     return results
-    
+
+
 @pytest.mark.p0
 def test_DarkNet53():
     """
@@ -87,6 +88,3 @@ def test_DarkNet53():
     # for test
     # np.save("DarkNet53.npy",with_lr_data[0])
     # print(np.argmax(with_lr_data[0][0]))
-
-
-

--- a/inference/inference_api_test/python_api_test/tests/gpu/test_v1_DenseNet121_gpu.py
+++ b/inference/inference_api_test/python_api_test/tests/gpu/test_v1_DenseNet121_gpu.py
@@ -49,7 +49,7 @@ def inference_DenseNet121(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/gpu/test_v1_EfficientNetB0_gpu.py
+++ b/inference/inference_api_test/python_api_test/tests/gpu/test_v1_EfficientNetB0_gpu.py
@@ -49,7 +49,7 @@ def inference_EfficientNetB0(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/gpu/test_v1_GhostNet_x1_3_gpu.py
+++ b/inference/inference_api_test/python_api_test/tests/gpu/test_v1_GhostNet_x1_3_gpu.py
@@ -49,7 +49,7 @@ def inference_GhostNet_x1_3(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/gpu/test_v1_GoogLeNet_gpu.py
+++ b/inference/inference_api_test/python_api_test/tests/gpu/test_v1_GoogLeNet_gpu.py
@@ -49,7 +49,7 @@ def inference_GoogLeNet(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()
@@ -62,7 +62,8 @@ def inference_GoogLeNet(img, model_path, params_path):
         output_data = output_tensor.copy_to_cpu()
         results.append(output_data)
     return results
-    
+
+
 @pytest.mark.p0
 def test_GoogLeNet():
     """
@@ -87,4 +88,3 @@ def test_GoogLeNet():
     # for test
     # np.save("GoogLeNet.npy",with_lr_data[0])
     # print(np.argmax(with_lr_data[0][0]))
-

--- a/inference/inference_api_test/python_api_test/tests/gpu/test_v1_HRNet_W18_C_gpu.py
+++ b/inference/inference_api_test/python_api_test/tests/gpu/test_v1_HRNet_W18_C_gpu.py
@@ -49,7 +49,7 @@ def inference_HRNet_W18_C(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/gpu/test_v1_InceptionV4_gpu.py
+++ b/inference/inference_api_test/python_api_test/tests/gpu/test_v1_InceptionV4_gpu.py
@@ -49,7 +49,7 @@ def inference_InceptionV4(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()
@@ -62,7 +62,8 @@ def inference_InceptionV4(img, model_path, params_path):
         output_data = output_tensor.copy_to_cpu()
         results.append(output_data)
     return results
-    
+
+
 @pytest.mark.p0
 def test_InceptionV4():
     """
@@ -83,8 +84,7 @@ def test_InceptionV4():
     with_lr_data = inference_InceptionV4(img, model_path, params_path)
     npy_result = test_model.npy_result_path("cv_class_model")
     test_model.test_diff(npy_result, with_lr_data[0], diff_standard)
-    
+
     # for test
     # np.save("InceptionV4.npy",with_lr_data[0])
     # print(np.argmax(with_lr_data[0][0]))
-

--- a/inference/inference_api_test/python_api_test/tests/gpu/test_v1_MobileNetV1_gpu.py
+++ b/inference/inference_api_test/python_api_test/tests/gpu/test_v1_MobileNetV1_gpu.py
@@ -49,7 +49,7 @@ def inference_MobileNetV1(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()
@@ -62,7 +62,8 @@ def inference_MobileNetV1(img, model_path, params_path):
         output_data = output_tensor.copy_to_cpu()
         results.append(output_data)
     return results
-    
+
+
 @pytest.mark.p0
 def test_MobileNetV1():
     """
@@ -83,8 +84,7 @@ def test_MobileNetV1():
     with_lr_data = inference_MobileNetV1(img, model_path, params_path)
     npy_result = test_model.npy_result_path("cv_class_model")
     test_model.test_diff(npy_result, with_lr_data[0], diff_standard)
-    
+
     # for test
     # np.save("MobileNetV1.npy",with_lr_data[0])
     # print(np.argmax(with_lr_data[0][0]))
-

--- a/inference/inference_api_test/python_api_test/tests/gpu/test_v1_MobileNetV2_gpu.py
+++ b/inference/inference_api_test/python_api_test/tests/gpu/test_v1_MobileNetV2_gpu.py
@@ -49,7 +49,7 @@ def inference_MobileNetV2(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/gpu/test_v1_MobileNetV3_large_gpu.py
+++ b/inference/inference_api_test/python_api_test/tests/gpu/test_v1_MobileNetV3_large_gpu.py
@@ -49,7 +49,7 @@ def inference_MobileNetV3_large(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/gpu/test_v1_RegNetX_4GF_gpu.py
+++ b/inference/inference_api_test/python_api_test/tests/gpu/test_v1_RegNetX_4GF_gpu.py
@@ -49,7 +49,7 @@ def inference_RegNetX_4GF(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/gpu/test_v1_Res2Net50_gpu.py
+++ b/inference/inference_api_test/python_api_test/tests/gpu/test_v1_Res2Net50_gpu.py
@@ -49,7 +49,7 @@ def inference_Res2Net50(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/gpu/test_v1_ResNeSt50_fast_gpu.py
+++ b/inference/inference_api_test/python_api_test/tests/gpu/test_v1_ResNeSt50_fast_gpu.py
@@ -49,7 +49,7 @@ def inference_ResNeSt50_fast(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/gpu/test_v1_ResNet50_gpu.py
+++ b/inference/inference_api_test/python_api_test/tests/gpu/test_v1_ResNet50_gpu.py
@@ -49,7 +49,7 @@ def inference_ResNet50(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/gpu/test_v1_ResNet50_vd_gpu.py
+++ b/inference/inference_api_test/python_api_test/tests/gpu/test_v1_ResNet50_vd_gpu.py
@@ -49,7 +49,7 @@ def inference_ResNet50_vd(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/gpu/test_v1_SE_ResNeXt50_gpu.py
+++ b/inference/inference_api_test/python_api_test/tests/gpu/test_v1_SE_ResNeXt50_gpu.py
@@ -49,7 +49,7 @@ def inference_SE_ResNeXt50(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/gpu/test_v1_ShuffleNetV2_gpu.py
+++ b/inference/inference_api_test/python_api_test/tests/gpu/test_v1_ShuffleNetV2_gpu.py
@@ -49,7 +49,7 @@ def inference_ShuffleNetV2(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/gpu/test_v1_SqueezeNet1_gpu.py
+++ b/inference/inference_api_test/python_api_test/tests/gpu/test_v1_SqueezeNet1_gpu.py
@@ -49,7 +49,7 @@ def inference_SqueezeNet1(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/gpu/test_v1_VGG11_gpu.py
+++ b/inference/inference_api_test/python_api_test/tests/gpu/test_v1_VGG11_gpu.py
@@ -49,7 +49,7 @@ def inference_VGG11(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/gpu/test_v1_Xception41_gpu.py
+++ b/inference/inference_api_test/python_api_test/tests/gpu/test_v1_Xception41_gpu.py
@@ -49,7 +49,7 @@ def inference_Xception41(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/gpu/test_v1_deeplabv3_resnet50_gpu.py
+++ b/inference/inference_api_test/python_api_test/tests/gpu/test_v1_deeplabv3_resnet50_gpu.py
@@ -21,6 +21,7 @@ from paddle.inference import Config
 from paddle.inference import create_predictor
 from test_src import test_gpu_model_jetson
 
+
 def inference_deeplabv3_resnet50(img, model_path, params_path):
     """
     inference_ttfnet
@@ -41,7 +42,7 @@ def inference_deeplabv3_resnet50(img, model_path, params_path):
 
     mean = [0.5, 0.5, 0.5]
     std = [0.5, 0.5, 0.5]
-    data = image_preprocess.normalize(img,mean,std)
+    data = image_preprocess.normalize(img, mean, std)
     data_input = np.array([data]).transpose([0, 3, 1, 2])
 
     predictor = create_predictor(config)
@@ -58,6 +59,7 @@ def inference_deeplabv3_resnet50(img, model_path, params_path):
     output_data = output_handle.copy_to_cpu()
 
     return output_data
+
 
 @pytest.mark.p0
 @pytest.mark.p1

--- a/inference/inference_api_test/python_api_test/tests/gpu/test_v1_deeplabv3p_resnet50_gpu.py
+++ b/inference/inference_api_test/python_api_test/tests/gpu/test_v1_deeplabv3p_resnet50_gpu.py
@@ -21,6 +21,7 @@ from paddle.inference import Config
 from paddle.inference import create_predictor
 from test_src import test_gpu_model_jetson
 
+
 def inference_deeplabv3p_resnet50(img, model_path, params_path):
     """
     inference_ttfnet
@@ -41,7 +42,7 @@ def inference_deeplabv3p_resnet50(img, model_path, params_path):
 
     mean = [0.5, 0.5, 0.5]
     std = [0.5, 0.5, 0.5]
-    data = image_preprocess.normalize(img,mean,std)
+    data = image_preprocess.normalize(img, mean, std)
     data_input = np.array([data]).transpose([0, 3, 1, 2])
 
     predictor = create_predictor(config)
@@ -58,6 +59,7 @@ def inference_deeplabv3p_resnet50(img, model_path, params_path):
     output_data = output_handle.copy_to_cpu()
 
     return output_data
+
 
 @pytest.mark.p0
 @pytest.mark.p1

--- a/inference/inference_api_test/python_api_test/tests/gpu/test_v1_faster_rcnn_r50_gpu.py
+++ b/inference/inference_api_test/python_api_test/tests/gpu/test_v1_faster_rcnn_r50_gpu.py
@@ -44,21 +44,21 @@ def inference_faster_rcnn_r50(img, model_path, params_path):
 
     predictor = create_predictor(config)
     input_names = predictor.get_input_names()
-   # input_handle0 = predictor.get_input_handle(input_names[0])
-   # input_handle1 = predictor.get_input_handle(input_names[1])
-   # input_handle2 = predictor.get_input_handle(input_names[2])
+    # input_handle0 = predictor.get_input_handle(input_names[0])
+    # input_handle1 = predictor.get_input_handle(input_names[1])
+    # input_handle2 = predictor.get_input_handle(input_names[2])
 
     im_size = 608
     data = image_preprocess.preprocess(img, im_size)
     scale_factor = np.array([im_size * 1. / img.shape[0], im_size *
-                            1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
+                             1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
     im_shape = np.array([im_size, im_size]).reshape((1, 2)).astype(np.float32)
     data_input = [im_shape, data, scale_factor]
 
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()
@@ -87,7 +87,7 @@ def test_faster_rcnn_r50():
     test_model = test_gpu_model_jetson(model_name=model_name)
     model_path, params_path = test_model.test_comb_model_path(
         "cv_detect_model")
-    #with_lr_data = inference_yolov3_r50vd(model_path,params_path,ir_optim=True)
+    # with_lr_data = inference_yolov3_r50vd(model_path,params_path,ir_optim=True)
     img_name = 'kite.jpg'
     image_path = test_model.test_readdata(
         path="cv_detect_model", data_name=img_name)

--- a/inference/inference_api_test/python_api_test/tests/gpu/test_v1_fcos_dcn_r50_fpn_gpu.py
+++ b/inference/inference_api_test/python_api_test/tests/gpu/test_v1_fcos_dcn_r50_fpn_gpu.py
@@ -44,21 +44,21 @@ def inference_fcos_dcn_r50_fpn(img, model_path, params_path):
 
     predictor = create_predictor(config)
     input_names = predictor.get_input_names()
-   # input_handle0 = predictor.get_input_handle(input_names[0])
-   # input_handle1 = predictor.get_input_handle(input_names[1])
-   # input_handle2 = predictor.get_input_handle(input_names[2])
+    # input_handle0 = predictor.get_input_handle(input_names[0])
+    # input_handle1 = predictor.get_input_handle(input_names[1])
+    # input_handle2 = predictor.get_input_handle(input_names[2])
 
     im_size = 608
     data = image_preprocess.preprocess(img, im_size)
     scale_factor = np.array([im_size * 1. / img.shape[0], im_size *
-                            1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
+                             1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
     im_shape = np.array([im_size, im_size]).reshape((1, 2)).astype(np.float32)
     data_input = [im_shape, data, scale_factor]
 
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()
@@ -87,7 +87,7 @@ def test_fcos_dcn_r50_fpn():
     test_model = test_gpu_model_jetson(model_name=model_name)
     model_path, params_path = test_model.test_comb_model_path(
         "cv_detect_model")
-    #with_lr_data = inference_yolov3_r50vd(model_path,params_path,ir_optim=True)
+    # with_lr_data = inference_yolov3_r50vd(model_path,params_path,ir_optim=True)
     img_name = 'kite.jpg'
     image_path = test_model.test_readdata(
         path="cv_detect_model", data_name=img_name)

--- a/inference/inference_api_test/python_api_test/tests/gpu/test_v1_ppyolo_r50vd_gpu.py
+++ b/inference/inference_api_test/python_api_test/tests/gpu/test_v1_ppyolo_r50vd_gpu.py
@@ -47,14 +47,14 @@ def inference_ppyolo_r50vd(img, model_path, params_path):
     im_size = 608
     data = image_preprocess.preprocess(img, im_size)
     scale_factor = np.array([im_size * 1. / img.shape[0], im_size *
-                            1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
+                             1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
     im_shape = np.array([im_size, im_size]).reshape((1, 2)).astype(np.float32)
     data_input = [im_shape, data, scale_factor]
 
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()
@@ -67,6 +67,7 @@ def inference_ppyolo_r50vd(img, model_path, params_path):
         output_data = output_tensor.copy_to_cpu()
         results.append(output_data)
     return results
+
 
 @pytest.mark.p0
 def test_ppyolo_r50vd():
@@ -82,16 +83,16 @@ def test_ppyolo_r50vd():
     test_model = test_gpu_model_jetson(model_name=model_name)
     model_path, params_path = test_model.test_comb_model_path(
         "cv_detect_model")
-    #with_lr_data = inference_yolov3_r50vd(model_path,params_path,ir_optim=True)
+    # with_lr_data = inference_yolov3_r50vd(model_path,params_path,ir_optim=True)
     img_name = 'kite.jpg'
     image_path = test_model.test_readdata(
         path="cv_detect_model", data_name=img_name)
     img = cv2.imread(image_path)
     with_lr_data = inference_ppyolo_r50vd(img, model_path, params_path)
-    
+
     npy_result = test_model.npy_result_path("cv_detect_model")
     test_model.test_diff(npy_result, with_lr_data[0], diff_standard)
-    
+
     # det image with box
     # np.save("ppyolo_r50vd.npy",with_lr_data[0])
     # image_preprocess.draw_bbox(image_path, with_lr_data[0], save_name="ppyolo_r50vd.jpg")

--- a/inference/inference_api_test/python_api_test/tests/gpu/test_v1_ppyolov2_r50vd_gpu.py
+++ b/inference/inference_api_test/python_api_test/tests/gpu/test_v1_ppyolov2_r50vd_gpu.py
@@ -46,14 +46,14 @@ def inference_ppyolov2_r50vd(img, model_path, params_path):
     im_size = 640
     data = image_preprocess.preprocess(img, im_size)
     scale_factor = np.array([im_size * 1. / img.shape[0], im_size *
-                            1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
+                             1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
     im_shape = np.array([im_size, im_size]).reshape((1, 2)).astype(np.float32)
     data_input = [im_shape, data, scale_factor]
 
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/gpu/test_v1_ssd_mobilenet_gpu.py
+++ b/inference/inference_api_test/python_api_test/tests/gpu/test_v1_ssd_mobilenet_gpu.py
@@ -45,14 +45,14 @@ def inference_ssd_mobilenet(img, model_path, params_path):
     im_size = 300
     data = image_preprocess.preprocess(img, im_size)
     scale_factor = np.array([im_size * 1. / img.shape[0], im_size *
-                            1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
+                             1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
     im_shape = np.array([im_size, im_size]).reshape((1, 2)).astype(np.float32)
     data_input = [im_shape, data, scale_factor]
 
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()
@@ -91,4 +91,4 @@ def test_ssd_mobilenet():
     test_model.test_diff(npy_result, with_lr_data[0], diff_standard)
 
     # det image with box
-    #image_preprocess.draw_bbox(image_path, with_lr_data[0], save_name="ssd_mobilenet.jpg")
+    # image_preprocess.draw_bbox(image_path, with_lr_data[0], save_name="ssd_mobilenet.jpg")

--- a/inference/inference_api_test/python_api_test/tests/gpu/test_v1_ssd_vgg16_gpu.py
+++ b/inference/inference_api_test/python_api_test/tests/gpu/test_v1_ssd_vgg16_gpu.py
@@ -45,14 +45,14 @@ def inference_ssd_vgg16(img, model_path, params_path):
     im_size = 300
     data = image_preprocess.preprocess(img, im_size)
     scale_factor = np.array([im_size * 1. / img.shape[0], im_size *
-                            1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
+                             1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
     im_shape = np.array([im_size, im_size]).reshape((1, 2)).astype(np.float32)
     data_input = [im_shape, data, scale_factor]
 
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/gpu/test_v1_ttfnet_gpu.py
+++ b/inference/inference_api_test/python_api_test/tests/gpu/test_v1_ttfnet_gpu.py
@@ -44,21 +44,21 @@ def inference_ttfnet(img, model_path, params_path):
 
     predictor = create_predictor(config)
     input_names = predictor.get_input_names()
-   # input_handle0 = predictor.get_input_handle(input_names[0])
-   # input_handle1 = predictor.get_input_handle(input_names[1])
-   # input_handle2 = predictor.get_input_handle(input_names[2])
+    # input_handle0 = predictor.get_input_handle(input_names[0])
+    # input_handle1 = predictor.get_input_handle(input_names[1])
+    # input_handle2 = predictor.get_input_handle(input_names[2])
 
     im_size = 512
     data = image_preprocess.preprocess(img, im_size)
     scale_factor = np.array([im_size * 1. / img.shape[0], im_size *
-                            1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
+                             1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
     im_shape = np.array([im_size, im_size]).reshape((1, 2)).astype(np.float32)
     data_input = [data, scale_factor]
 
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()
@@ -87,7 +87,7 @@ def test_ttfnet():
     test_model = test_gpu_model_jetson(model_name=model_name)
     model_path, params_path = test_model.test_comb_model_path(
         "cv_detect_model")
-    #with_lr_data = inference_yolov3_r50vd(model_path,params_path,ir_optim=True)
+    # with_lr_data = inference_yolov3_r50vd(model_path,params_path,ir_optim=True)
     img_name = 'kite.jpg'
     image_path = test_model.test_readdata(
         path="cv_detect_model", data_name=img_name)
@@ -97,4 +97,4 @@ def test_ttfnet():
     test_model.test_diff(npy_result, with_lr_data[0], diff_standard)
 
     # det image with box
-    #image_preprocess.draw_bbox(img_name, without_lr_data[0], save_name="ttfnet.jpg")
+    # image_preprocess.draw_bbox(img_name, without_lr_data[0], save_name="ttfnet.jpg")

--- a/inference/inference_api_test/python_api_test/tests/gpu/test_v1_unet_gpu.py
+++ b/inference/inference_api_test/python_api_test/tests/gpu/test_v1_unet_gpu.py
@@ -21,6 +21,7 @@ from paddle.inference import Config
 from paddle.inference import create_predictor
 from test_src import test_gpu_model_jetson
 
+
 def inference_unet(img, model_path, params_path):
     """
     inference_unet
@@ -41,7 +42,7 @@ def inference_unet(img, model_path, params_path):
 
     mean = [0.5, 0.5, 0.5]
     std = [0.5, 0.5, 0.5]
-    data = image_preprocess.normalize(img,mean,std)
+    data = image_preprocess.normalize(img, mean, std)
     data_input = np.array([data]).transpose([0, 3, 1, 2])
 
     predictor = create_predictor(config)
@@ -58,6 +59,7 @@ def inference_unet(img, model_path, params_path):
     output_data = output_handle.copy_to_cpu()
 
     return output_data
+
 
 @pytest.mark.p0
 @pytest.mark.p1
@@ -80,7 +82,7 @@ def test_unet():
     with_lr_data = inference_unet(img, model_path, params_path)
     npy_result = test_model.npy_result_path("cv_seg_model")
     test_model.test_diff(npy_result, with_lr_data[0], diff_standard)
-    
+
     # save color img
     # np.save("unet.npy",with_lr_data[0]) 
     # imgs = np.argmax(with_lr_data[0], axis=0)

--- a/inference/inference_api_test/python_api_test/tests/gpu/test_v1_yolov3_darknet53_gpu.py
+++ b/inference/inference_api_test/python_api_test/tests/gpu/test_v1_yolov3_darknet53_gpu.py
@@ -47,14 +47,14 @@ def inference_yolov3_darknet53(img, model_path, params_path):
     im_size = 608
     data = image_preprocess.preprocess(img, im_size)
     scale_factor = np.array([im_size * 1. / img.shape[0], im_size *
-                            1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
+                             1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
     im_shape = np.array([im_size, im_size]).reshape((1, 2)).astype(np.float32)
     data_input = [im_shape, data, scale_factor]
 
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()
@@ -83,7 +83,7 @@ def test_yolov3_darknet53():
     test_model = test_gpu_model_jetson(model_name=model_name)
     model_path, params_path = test_model.test_comb_model_path(
         "cv_detect_model")
-    #with_lr_data = inference_yolov3_r50vd(model_path,params_path,ir_optim=True)
+    # with_lr_data = inference_yolov3_r50vd(model_path,params_path,ir_optim=True)
     img_name = 'kite.jpg'
     image_path = test_model.test_readdata(
         path="cv_detect_model", data_name=img_name)

--- a/inference/inference_api_test/python_api_test/tests/gpu/test_v1_yolov3_mobilenet_v1_gpu.py
+++ b/inference/inference_api_test/python_api_test/tests/gpu/test_v1_yolov3_mobilenet_v1_gpu.py
@@ -47,14 +47,14 @@ def inference_yolov3_mobilenet_v1(img, model_path, params_path):
     im_size = 608
     data = image_preprocess.preprocess(img, im_size)
     scale_factor = np.array([im_size * 1. / img.shape[0], im_size *
-                            1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
+                             1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
     im_shape = np.array([im_size, im_size]).reshape((1, 2)).astype(np.float32)
     data_input = [im_shape, data, scale_factor]
 
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()
@@ -83,7 +83,7 @@ def test_yolov3_mobilenet_v1():
     test_model = test_gpu_model_jetson(model_name=model_name)
     model_path, params_path = test_model.test_comb_model_path(
         "cv_detect_model")
-    #with_lr_data = inference_yolov3_mobilenet_v1(model_path,params_path,ir_optim=True)
+    # with_lr_data = inference_yolov3_mobilenet_v1(model_path,params_path,ir_optim=True)
     img_name = 'kite.jpg'
     image_path = test_model.test_readdata(
         path="cv_detect_model", data_name=img_name)

--- a/inference/inference_api_test/python_api_test/tests/gpu/test_v1_yolov3_r50vd_gpu.py
+++ b/inference/inference_api_test/python_api_test/tests/gpu/test_v1_yolov3_r50vd_gpu.py
@@ -47,14 +47,14 @@ def inference_yolov3_r50vd(img, model_path, params_path):
     im_size = 608
     data = image_preprocess.preprocess(img, im_size)
     scale_factor = np.array([im_size * 1. / img.shape[0], im_size *
-                            1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
+                             1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
     im_shape = np.array([im_size, im_size]).reshape((1, 2)).astype(np.float32)
     data_input = [im_shape, data, scale_factor]
 
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()
@@ -67,6 +67,7 @@ def inference_yolov3_r50vd(img, model_path, params_path):
         output_data = output_tensor.copy_to_cpu()
         results.append(output_data)
     return results
+
 
 @pytest.mark.p0
 def test_yolov3_r50vd():
@@ -82,7 +83,7 @@ def test_yolov3_r50vd():
     test_model = test_gpu_model_jetson(model_name=model_name)
     model_path, params_path = test_model.test_comb_model_path(
         "cv_detect_model")
-    #with_lr_data = inference_yolov3_r50vd(model_path,params_path,ir_optim=True)
+    # with_lr_data = inference_yolov3_r50vd(model_path,params_path,ir_optim=True)
     img_name = 'kite.jpg'
     image_path = test_model.test_readdata(
         path="cv_detect_model", data_name=img_name)
@@ -90,7 +91,7 @@ def test_yolov3_r50vd():
     with_lr_data = inference_yolov3_r50vd(img, model_path, params_path)
     npy_result = test_model.npy_result_path("cv_detect_model")
     test_model.test_diff(npy_result, with_lr_data[0], diff_standard)
-    
+
     # det image with box
     # np.save("yolov3_r50vd.npy",with_lr_data[0])
     # image_preprocess.draw_bbox(

--- a/inference/inference_api_test/python_api_test/tests/trt_fp32/test_serialize_resnet50_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/trt_fp32/test_serialize_resnet50_trt_fp32.py
@@ -32,6 +32,7 @@ FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 logging.basicConfig(level=logging.INFO, format=FORMAT)
 logger = logging.getLogger(__name__)
 
+
 def prepare_predictor(model_path, trt_max_batch_size=1):
     """
     prepare predictor
@@ -68,7 +69,7 @@ def run_inference(predictor, img):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(img[i].shape)
-        input_tensor.copy_from_cpu(img[i].copy())
+        input_tensor.copy_from_cpu(img[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_AlexNet_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_AlexNet_trt_fp32.py
@@ -40,13 +40,13 @@ def inference_AlexNet(img, model_path, params_path):
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
     config.enable_memory_optim()
-    config.enable_tensorrt_engine(1 << 30,    # workspace_size
-            10,    # max_batch_size
-            30,    # min_subgraph_size
-            PrecisionType.Float32,    # precision
-            True,    # use_static
-            False,    # use_calib_mode
-            )
+    config.enable_tensorrt_engine(1 << 30,  # workspace_size
+                                  10,  # max_batch_size
+                                  30,  # min_subgraph_size
+                                  PrecisionType.Float32,  # precision
+                                  True,  # use_static
+                                  False,  # use_calib_mode
+                                  )
     predictor = create_predictor(config)
     input_names = predictor.get_input_names()
 
@@ -56,7 +56,7 @@ def inference_AlexNet(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()
@@ -69,7 +69,8 @@ def inference_AlexNet(img, model_path, params_path):
         output_data = output_tensor.copy_to_cpu()
         results.append(output_data)
     return results
-    
+
+
 @pytest.mark.p0
 def test_AlexNet():
     """
@@ -94,5 +95,3 @@ def test_AlexNet():
     # for test images class 
     # np.save("AlexNet.npy",with_lr_data[0])
     # print(np.argmax(with_lr_data[0][0]))
-
-

--- a/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_DPN68_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_DPN68_trt_fp32.py
@@ -40,13 +40,13 @@ def inference_DPN68(img, model_path, params_path):
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
     config.enable_memory_optim()
-    config.enable_tensorrt_engine(1 << 30,    # workspace_size
-            10,    # max_batch_size
-            30,    # min_subgraph_size
-            PrecisionType.Float32,    # precision
-            True,    # use_static
-            False,    # use_calib_mode
-            )
+    config.enable_tensorrt_engine(1 << 30,  # workspace_size
+                                  10,  # max_batch_size
+                                  30,  # min_subgraph_size
+                                  PrecisionType.Float32,  # precision
+                                  True,  # use_static
+                                  False,  # use_calib_mode
+                                  )
     predictor = create_predictor(config)
     input_names = predictor.get_input_names()
 
@@ -56,7 +56,7 @@ def inference_DPN68(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_DarkNet53_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_DarkNet53_trt_fp32.py
@@ -40,13 +40,13 @@ def inference_DarkNet53(img, model_path, params_path):
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
     config.enable_memory_optim()
-    config.enable_tensorrt_engine(1 << 30,    # workspace_size
-            10,    # max_batch_size
-            30,    # min_subgraph_size
-            PrecisionType.Float32,    # precision
-            True,    # use_static
-            False,    # use_calib_mode
-            )
+    config.enable_tensorrt_engine(1 << 30,  # workspace_size
+                                  10,  # max_batch_size
+                                  30,  # min_subgraph_size
+                                  PrecisionType.Float32,  # precision
+                                  True,  # use_static
+                                  False,  # use_calib_mode
+                                  )
     predictor = create_predictor(config)
     input_names = predictor.get_input_names()
 
@@ -56,7 +56,7 @@ def inference_DarkNet53(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()
@@ -69,7 +69,8 @@ def inference_DarkNet53(img, model_path, params_path):
         output_data = output_tensor.copy_to_cpu()
         results.append(output_data)
     return results
-    
+
+
 @pytest.mark.p0
 def test_DarkNet53():
     """
@@ -94,6 +95,3 @@ def test_DarkNet53():
     # for test
     # np.save("DarkNet53.npy",with_lr_data[0])
     # print(np.argmax(with_lr_data[0][0]))
-
-
-

--- a/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_DenseNet121_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_DenseNet121_trt_fp32.py
@@ -40,13 +40,13 @@ def inference_DenseNet121(img, model_path, params_path):
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
     config.enable_memory_optim()
-    config.enable_tensorrt_engine(1 << 30,    # workspace_size
-            10,    # max_batch_size
-            30,    # min_subgraph_size
-            PrecisionType.Float32,    # precision
-            True,    # use_static
-            False,    # use_calib_mode
-            )
+    config.enable_tensorrt_engine(1 << 30,  # workspace_size
+                                  10,  # max_batch_size
+                                  30,  # min_subgraph_size
+                                  PrecisionType.Float32,  # precision
+                                  True,  # use_static
+                                  False,  # use_calib_mode
+                                  )
     predictor = create_predictor(config)
     input_names = predictor.get_input_names()
 
@@ -56,7 +56,7 @@ def inference_DenseNet121(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_EfficientNetB0_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_EfficientNetB0_trt_fp32.py
@@ -40,13 +40,13 @@ def inference_EfficientNetB0(img, model_path, params_path):
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
     config.enable_memory_optim()
-    config.enable_tensorrt_engine(1 << 30,    # workspace_size
-            10,    # max_batch_size
-            50,    # min_subgraph_size
-            PrecisionType.Float32,    # precision
-            False,    # use_static
-            False,    # use_calib_mode
-            )
+    config.enable_tensorrt_engine(1 << 30,  # workspace_size
+                                  10,  # max_batch_size
+                                  50,  # min_subgraph_size
+                                  PrecisionType.Float32,  # precision
+                                  False,  # use_static
+                                  False,  # use_calib_mode
+                                  )
     predictor = create_predictor(config)
     input_names = predictor.get_input_names()
 
@@ -56,7 +56,7 @@ def inference_EfficientNetB0(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_GhostNet_x1_3_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_GhostNet_x1_3_trt_fp32.py
@@ -40,13 +40,13 @@ def inference_GhostNet_x1_3(img, model_path, params_path):
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
     config.enable_memory_optim()
-    config.enable_tensorrt_engine(1 << 30,    # workspace_size
-            10,    # max_batch_size
-            30,    # min_subgraph_size
-            PrecisionType.Float32,    # precision
-            True,    # use_static
-            False,    # use_calib_mode
-            )
+    config.enable_tensorrt_engine(1 << 30,  # workspace_size
+                                  10,  # max_batch_size
+                                  30,  # min_subgraph_size
+                                  PrecisionType.Float32,  # precision
+                                  True,  # use_static
+                                  False,  # use_calib_mode
+                                  )
     predictor = create_predictor(config)
     input_names = predictor.get_input_names()
 
@@ -56,7 +56,7 @@ def inference_GhostNet_x1_3(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_GoogLeNet_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_GoogLeNet_trt_fp32.py
@@ -40,13 +40,13 @@ def inference_GoogLeNet(img, model_path, params_path):
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
     config.enable_memory_optim()
-    config.enable_tensorrt_engine(1 << 30,    # workspace_size
-            10,    # max_batch_size
-            30,    # min_subgraph_size
-            PrecisionType.Float32,    # precision
-            True,    # use_static
-            False,    # use_calib_mode
-            )
+    config.enable_tensorrt_engine(1 << 30,  # workspace_size
+                                  10,  # max_batch_size
+                                  30,  # min_subgraph_size
+                                  PrecisionType.Float32,  # precision
+                                  True,  # use_static
+                                  False,  # use_calib_mode
+                                  )
     predictor = create_predictor(config)
     input_names = predictor.get_input_names()
 
@@ -56,7 +56,7 @@ def inference_GoogLeNet(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()
@@ -69,7 +69,8 @@ def inference_GoogLeNet(img, model_path, params_path):
         output_data = output_tensor.copy_to_cpu()
         results.append(output_data)
     return results
-    
+
+
 @pytest.mark.p0
 def test_GoogLeNet():
     """
@@ -94,4 +95,3 @@ def test_GoogLeNet():
     # for test
     # np.save("GoogLeNet.npy",with_lr_data[0])
     # print(np.argmax(with_lr_data[0][0]))
-

--- a/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_HRNet_W18_C_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_HRNet_W18_C_trt_fp32.py
@@ -40,13 +40,13 @@ def inference_HRNet_W18_C(img, model_path, params_path):
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
     config.enable_memory_optim()
-    config.enable_tensorrt_engine(1 << 30,    # workspace_size
-            10,    # max_batch_size
-            30,    # min_subgraph_size
-            PrecisionType.Float32,    # precision
-            True,    # use_static
-            False,    # use_calib_mode
-            )
+    config.enable_tensorrt_engine(1 << 30,  # workspace_size
+                                  10,  # max_batch_size
+                                  30,  # min_subgraph_size
+                                  PrecisionType.Float32,  # precision
+                                  True,  # use_static
+                                  False,  # use_calib_mode
+                                  )
     predictor = create_predictor(config)
     input_names = predictor.get_input_names()
 
@@ -56,7 +56,7 @@ def inference_HRNet_W18_C(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_InceptionV4_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_InceptionV4_trt_fp32.py
@@ -40,13 +40,13 @@ def inference_InceptionV4(img, model_path, params_path):
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
     config.enable_memory_optim()
-    config.enable_tensorrt_engine(1 << 30,    # workspace_size
-            10,    # max_batch_size
-            30,    # min_subgraph_size
-            PrecisionType.Float32,    # precision
-            True,    # use_static
-            False,    # use_calib_mode
-            )
+    config.enable_tensorrt_engine(1 << 30,  # workspace_size
+                                  10,  # max_batch_size
+                                  30,  # min_subgraph_size
+                                  PrecisionType.Float32,  # precision
+                                  True,  # use_static
+                                  False,  # use_calib_mode
+                                  )
     predictor = create_predictor(config)
     input_names = predictor.get_input_names()
 
@@ -56,7 +56,7 @@ def inference_InceptionV4(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()
@@ -69,7 +69,8 @@ def inference_InceptionV4(img, model_path, params_path):
         output_data = output_tensor.copy_to_cpu()
         results.append(output_data)
     return results
-    
+
+
 @pytest.mark.p0
 def test_InceptionV4():
     """
@@ -90,8 +91,7 @@ def test_InceptionV4():
     with_lr_data = inference_InceptionV4(img, model_path, params_path)
     npy_result = test_model.npy_result_path("cv_class_model")
     test_model.test_diff(npy_result, with_lr_data[0], diff_standard)
-    
+
     # for test
     # np.save("InceptionV4.npy",with_lr_data[0])
     # print(np.argmax(with_lr_data[0][0]))
-

--- a/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_MobileNetV1_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_MobileNetV1_trt_fp32.py
@@ -40,13 +40,13 @@ def inference_MobileNetV1(img, model_path, params_path):
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
     config.enable_memory_optim()
-    config.enable_tensorrt_engine(1 << 30,    # workspace_size
-            10,    # max_batch_size
-            30,    # min_subgraph_size
-            PrecisionType.Float32,    # precision
-            True,    # use_static
-            False,    # use_calib_mode
-            )
+    config.enable_tensorrt_engine(1 << 30,  # workspace_size
+                                  10,  # max_batch_size
+                                  30,  # min_subgraph_size
+                                  PrecisionType.Float32,  # precision
+                                  True,  # use_static
+                                  False,  # use_calib_mode
+                                  )
     predictor = create_predictor(config)
     input_names = predictor.get_input_names()
 
@@ -56,7 +56,7 @@ def inference_MobileNetV1(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()
@@ -69,7 +69,8 @@ def inference_MobileNetV1(img, model_path, params_path):
         output_data = output_tensor.copy_to_cpu()
         results.append(output_data)
     return results
-    
+
+
 @pytest.mark.p0
 def test_MobileNetV1():
     """
@@ -90,8 +91,7 @@ def test_MobileNetV1():
     with_lr_data = inference_MobileNetV1(img, model_path, params_path)
     npy_result = test_model.npy_result_path("cv_class_model")
     test_model.test_diff(npy_result, with_lr_data[0], diff_standard)
-    
+
     # for test
     # np.save("MobileNetV1.npy",with_lr_data[0])
     # print(np.argmax(with_lr_data[0][0]))
-

--- a/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_MobileNetV2_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_MobileNetV2_trt_fp32.py
@@ -40,13 +40,13 @@ def inference_MobileNetV2(img, model_path, params_path):
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
     config.enable_memory_optim()
-    config.enable_tensorrt_engine(1 << 30,    # workspace_size
-            10,    # max_batch_size
-            30,    # min_subgraph_size
-            PrecisionType.Float32,    # precision
-            True,    # use_static
-            False,    # use_calib_mode
-            )
+    config.enable_tensorrt_engine(1 << 30,  # workspace_size
+                                  10,  # max_batch_size
+                                  30,  # min_subgraph_size
+                                  PrecisionType.Float32,  # precision
+                                  True,  # use_static
+                                  False,  # use_calib_mode
+                                  )
     predictor = create_predictor(config)
     input_names = predictor.get_input_names()
 
@@ -56,7 +56,7 @@ def inference_MobileNetV2(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_MobileNetV3_large_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_MobileNetV3_large_trt_fp32.py
@@ -40,13 +40,13 @@ def inference_MobileNetV3_large(img, model_path, params_path):
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
     config.enable_memory_optim()
-    config.enable_tensorrt_engine(1 << 30,    # workspace_size
-            10,    # max_batch_size
-            30,    # min_subgraph_size
-            PrecisionType.Float32,    # precision
-            True,    # use_static
-            False,    # use_calib_mode
-            )
+    config.enable_tensorrt_engine(1 << 30,  # workspace_size
+                                  10,  # max_batch_size
+                                  30,  # min_subgraph_size
+                                  PrecisionType.Float32,  # precision
+                                  True,  # use_static
+                                  False,  # use_calib_mode
+                                  )
     predictor = create_predictor(config)
     input_names = predictor.get_input_names()
 
@@ -56,7 +56,7 @@ def inference_MobileNetV3_large(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_RegNetX_4GF_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_RegNetX_4GF_trt_fp32.py
@@ -40,13 +40,13 @@ def inference_RegNetX_4GF(img, model_path, params_path):
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
     config.enable_memory_optim()
-    config.enable_tensorrt_engine(1 << 30,    # workspace_size
-            10,    # max_batch_size
-            30,    # min_subgraph_size
-            PrecisionType.Float32,    # precision
-            True,    # use_static
-            False,    # use_calib_mode
-            )
+    config.enable_tensorrt_engine(1 << 30,  # workspace_size
+                                  10,  # max_batch_size
+                                  30,  # min_subgraph_size
+                                  PrecisionType.Float32,  # precision
+                                  True,  # use_static
+                                  False,  # use_calib_mode
+                                  )
     predictor = create_predictor(config)
     input_names = predictor.get_input_names()
 
@@ -56,7 +56,7 @@ def inference_RegNetX_4GF(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_Res2Net50_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_Res2Net50_trt_fp32.py
@@ -40,13 +40,13 @@ def inference_Res2Net50(img, model_path, params_path):
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
     config.enable_memory_optim()
-    config.enable_tensorrt_engine(1 << 30,    # workspace_size
-            10,    # max_batch_size
-            30,    # min_subgraph_size
-            PrecisionType.Float32,    # precision
-            True,    # use_static
-            False,    # use_calib_mode
-            )
+    config.enable_tensorrt_engine(1 << 30,  # workspace_size
+                                  10,  # max_batch_size
+                                  30,  # min_subgraph_size
+                                  PrecisionType.Float32,  # precision
+                                  True,  # use_static
+                                  False,  # use_calib_mode
+                                  )
     predictor = create_predictor(config)
     input_names = predictor.get_input_names()
 
@@ -56,7 +56,7 @@ def inference_Res2Net50(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_ResNeSt50_fast_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_ResNeSt50_fast_trt_fp32.py
@@ -40,13 +40,13 @@ def inference_ResNeSt50_fast(img, model_path, params_path):
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
     config.enable_memory_optim()
-    config.enable_tensorrt_engine(1 << 30,    # workspace_size
-            10,    # max_batch_size
-            30,    # min_subgraph_size
-            PrecisionType.Float32,    # precision
-            True,    # use_static
-            False,    # use_calib_mode
-            )
+    config.enable_tensorrt_engine(1 << 30,  # workspace_size
+                                  10,  # max_batch_size
+                                  30,  # min_subgraph_size
+                                  PrecisionType.Float32,  # precision
+                                  True,  # use_static
+                                  False,  # use_calib_mode
+                                  )
     predictor = create_predictor(config)
     input_names = predictor.get_input_names()
 
@@ -56,7 +56,7 @@ def inference_ResNeSt50_fast(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_ResNet50_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_ResNet50_trt_fp32.py
@@ -40,13 +40,13 @@ def inference_ResNet50(img, model_path, params_path):
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
     config.enable_memory_optim()
-    config.enable_tensorrt_engine(1 << 30,    # workspace_size
-            10,    # max_batch_size
-            30,    # min_subgraph_size
-            PrecisionType.Float32,    # precision
-            True,    # use_static
-            False,    # use_calib_mode
-            )
+    config.enable_tensorrt_engine(1 << 30,  # workspace_size
+                                  10,  # max_batch_size
+                                  30,  # min_subgraph_size
+                                  PrecisionType.Float32,  # precision
+                                  True,  # use_static
+                                  False,  # use_calib_mode
+                                  )
     predictor = create_predictor(config)
     input_names = predictor.get_input_names()
 
@@ -56,7 +56,7 @@ def inference_ResNet50(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_ResNet50_vd_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_ResNet50_vd_trt_fp32.py
@@ -40,13 +40,13 @@ def inference_ResNet50_vd(img, model_path, params_path):
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
     config.enable_memory_optim()
-    config.enable_tensorrt_engine(1 << 30,    # workspace_size
-            10,    # max_batch_size
-            30,    # min_subgraph_size
-            PrecisionType.Float32,    # precision
-            True,    # use_static
-            False,    # use_calib_mode
-            )
+    config.enable_tensorrt_engine(1 << 30,  # workspace_size
+                                  10,  # max_batch_size
+                                  30,  # min_subgraph_size
+                                  PrecisionType.Float32,  # precision
+                                  True,  # use_static
+                                  False,  # use_calib_mode
+                                  )
     predictor = create_predictor(config)
     input_names = predictor.get_input_names()
 
@@ -56,7 +56,7 @@ def inference_ResNet50_vd(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_SE_ResNeXt50_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_SE_ResNeXt50_trt_fp32.py
@@ -40,13 +40,13 @@ def inference_SE_ResNeXt50(img, model_path, params_path):
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
     config.enable_memory_optim()
-    config.enable_tensorrt_engine(1 << 30,    # workspace_size
-            10,    # max_batch_size
-            30,    # min_subgraph_size
-            PrecisionType.Float32,    # precision
-            True,    # use_static
-            False,    # use_calib_mode
-            )
+    config.enable_tensorrt_engine(1 << 30,  # workspace_size
+                                  10,  # max_batch_size
+                                  30,  # min_subgraph_size
+                                  PrecisionType.Float32,  # precision
+                                  True,  # use_static
+                                  False,  # use_calib_mode
+                                  )
     predictor = create_predictor(config)
     input_names = predictor.get_input_names()
 
@@ -56,7 +56,7 @@ def inference_SE_ResNeXt50(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_ShuffleNetV2_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_ShuffleNetV2_trt_fp32.py
@@ -40,13 +40,13 @@ def inference_ShuffleNetV2(img, model_path, params_path):
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
     config.enable_memory_optim()
-    config.enable_tensorrt_engine(1 << 30,    # workspace_size
-            10,    # max_batch_size
-            30,    # min_subgraph_size
-            PrecisionType.Float32,    # precision
-            True,    # use_static
-            False,    # use_calib_mode
-            )
+    config.enable_tensorrt_engine(1 << 30,  # workspace_size
+                                  10,  # max_batch_size
+                                  30,  # min_subgraph_size
+                                  PrecisionType.Float32,  # precision
+                                  True,  # use_static
+                                  False,  # use_calib_mode
+                                  )
     predictor = create_predictor(config)
     input_names = predictor.get_input_names()
 
@@ -56,7 +56,7 @@ def inference_ShuffleNetV2(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_SqueezeNet1_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_SqueezeNet1_trt_fp32.py
@@ -40,13 +40,13 @@ def inference_SqueezeNet1(img, model_path, params_path):
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
     config.enable_memory_optim()
-    config.enable_tensorrt_engine(1 << 30,    # workspace_size
-            10,    # max_batch_size
-            30,    # min_subgraph_size
-            PrecisionType.Float32,    # precision
-            True,    # use_static
-            False,    # use_calib_mode
-            )
+    config.enable_tensorrt_engine(1 << 30,  # workspace_size
+                                  10,  # max_batch_size
+                                  30,  # min_subgraph_size
+                                  PrecisionType.Float32,  # precision
+                                  True,  # use_static
+                                  False,  # use_calib_mode
+                                  )
     predictor = create_predictor(config)
     input_names = predictor.get_input_names()
 
@@ -56,7 +56,7 @@ def inference_SqueezeNet1(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_VGG11_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_VGG11_trt_fp32.py
@@ -40,13 +40,13 @@ def inference_VGG11(img, model_path, params_path):
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
     config.enable_memory_optim()
-    config.enable_tensorrt_engine(1 << 30,    # workspace_size
-            10,    # max_batch_size
-            30,    # min_subgraph_size
-            PrecisionType.Float32,    # precision
-            True,    # use_static
-            False,    # use_calib_mode
-            )
+    config.enable_tensorrt_engine(1 << 30,  # workspace_size
+                                  10,  # max_batch_size
+                                  30,  # min_subgraph_size
+                                  PrecisionType.Float32,  # precision
+                                  True,  # use_static
+                                  False,  # use_calib_mode
+                                  )
     predictor = create_predictor(config)
     input_names = predictor.get_input_names()
 
@@ -56,7 +56,7 @@ def inference_VGG11(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_Xception41_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_Xception41_trt_fp32.py
@@ -40,13 +40,13 @@ def inference_Xception41(img, model_path, params_path):
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
     config.enable_memory_optim()
-    config.enable_tensorrt_engine(1 << 30,    # workspace_size
-            10,    # max_batch_size
-            30,    # min_subgraph_size
-            PrecisionType.Float32,    # precision
-            True,    # use_static
-            False,    # use_calib_mode
-            )
+    config.enable_tensorrt_engine(1 << 30,  # workspace_size
+                                  10,  # max_batch_size
+                                  30,  # min_subgraph_size
+                                  PrecisionType.Float32,  # precision
+                                  True,  # use_static
+                                  False,  # use_calib_mode
+                                  )
     predictor = create_predictor(config)
     input_names = predictor.get_input_names()
 
@@ -56,7 +56,7 @@ def inference_Xception41(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_deeplabv3_resnet50_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_deeplabv3_resnet50_trt_fp32.py
@@ -22,6 +22,7 @@ from paddle.inference import PrecisionType
 from paddle.inference import create_predictor
 from test_src import test_gpu_model_jetson
 
+
 def inference_deeplabv3_resnet50(img, model_path, params_path):
     """
     inference_ttfnet
@@ -39,16 +40,16 @@ def inference_deeplabv3_resnet50(img, model_path, params_path):
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
     config.enable_memory_optim()
-    config.enable_tensorrt_engine(1 << 30,    # workspace_size
-            1,    # max_batch_size
-            50,    # min_subgraph_size
-            PrecisionType.Float32,    # precision
-            False,    # use_static
-            False,    # use_calib_mode
-            )
+    config.enable_tensorrt_engine(1 << 30,  # workspace_size
+                                  1,  # max_batch_size
+                                  50,  # min_subgraph_size
+                                  PrecisionType.Float32,  # precision
+                                  False,  # use_static
+                                  False,  # use_calib_mode
+                                  )
     mean = [0.5, 0.5, 0.5]
     std = [0.5, 0.5, 0.5]
-    data = image_preprocess.normalize(img,mean,std)
+    data = image_preprocess.normalize(img, mean, std)
     data_input = np.array([data]).transpose([0, 3, 1, 2])
 
     predictor = create_predictor(config)
@@ -65,6 +66,7 @@ def inference_deeplabv3_resnet50(img, model_path, params_path):
     output_data = output_handle.copy_to_cpu()
 
     return output_data
+
 
 @pytest.mark.p0
 @pytest.mark.p1

--- a/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_deeplabv3p_resnet50_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_deeplabv3p_resnet50_trt_fp32.py
@@ -22,6 +22,7 @@ from paddle.inference import PrecisionType
 from paddle.inference import create_predictor
 from test_src import test_gpu_model_jetson
 
+
 def inference_deeplabv3p_resnet50(img, model_path, params_path):
     """
     inference_ttfnet
@@ -39,16 +40,16 @@ def inference_deeplabv3p_resnet50(img, model_path, params_path):
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
     config.enable_memory_optim()
-    config.enable_tensorrt_engine(1 << 30,    # workspace_size
-            1,    # max_batch_size
-            50,    # min_subgraph_size
-            PrecisionType.Float32,    # precision
-            False,    # use_static
-            False,    # use_calib_mode
-            )
+    config.enable_tensorrt_engine(1 << 30,  # workspace_size
+                                  1,  # max_batch_size
+                                  50,  # min_subgraph_size
+                                  PrecisionType.Float32,  # precision
+                                  False,  # use_static
+                                  False,  # use_calib_mode
+                                  )
     mean = [0.5, 0.5, 0.5]
     std = [0.5, 0.5, 0.5]
-    data = image_preprocess.normalize(img,mean,std)
+    data = image_preprocess.normalize(img, mean, std)
     data_input = np.array([data]).transpose([0, 3, 1, 2])
 
     predictor = create_predictor(config)
@@ -65,6 +66,7 @@ def inference_deeplabv3p_resnet50(img, model_path, params_path):
     output_data = output_handle.copy_to_cpu()
 
     return output_data
+
 
 @pytest.mark.p0
 @pytest.mark.p1

--- a/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_faster_rcnn_r50_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_faster_rcnn_r50_trt_fp32.py
@@ -42,30 +42,30 @@ def inference_faster_rcnn_r50(img, model_path, params_path):
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
     config.enable_memory_optim()
-    config.enable_tensorrt_engine(1 << 30,    # workspace_size
-            10,    # max_batch_size
-            30,    # min_subgraph_size
-            PrecisionType.Float32,    # precision
-            True,    # use_static
-            False,    # use_calib_mode
-            )
+    config.enable_tensorrt_engine(1 << 30,  # workspace_size
+                                  10,  # max_batch_size
+                                  30,  # min_subgraph_size
+                                  PrecisionType.Float32,  # precision
+                                  True,  # use_static
+                                  False,  # use_calib_mode
+                                  )
     predictor = create_predictor(config)
     input_names = predictor.get_input_names()
-   # input_handle0 = predictor.get_input_handle(input_names[0])
-   # input_handle1 = predictor.get_input_handle(input_names[1])
-   # input_handle2 = predictor.get_input_handle(input_names[2])
+    # input_handle0 = predictor.get_input_handle(input_names[0])
+    # input_handle1 = predictor.get_input_handle(input_names[1])
+    # input_handle2 = predictor.get_input_handle(input_names[2])
 
     im_size = 608
     data = image_preprocess.preprocess(img, im_size)
     scale_factor = np.array([im_size * 1. / img.shape[0], im_size *
-                            1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
+                             1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
     im_shape = np.array([im_size, im_size]).reshape((1, 2)).astype(np.float32)
     data_input = [im_shape, data, scale_factor]
 
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()
@@ -94,7 +94,7 @@ def test_faster_rcnn_r50():
     test_model = test_gpu_model_jetson(model_name=model_name)
     model_path, params_path = test_model.test_comb_model_path(
         "cv_detect_model")
-    #with_lr_data = inference_yolov3_r50vd(model_path,params_path,ir_optim=True)
+    # with_lr_data = inference_yolov3_r50vd(model_path,params_path,ir_optim=True)
     img_name = 'kite.jpg'
     image_path = test_model.test_readdata(
         path="cv_detect_model", data_name=img_name)

--- a/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_fcn_hrnetw18_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_fcn_hrnetw18_trt_fp32.py
@@ -40,13 +40,13 @@ def inference_fcn_hrnetw18(img, model_path, params_path):
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
     config.enable_memory_optim()
-    config.enable_tensorrt_engine(1 << 30,    # workspace_size
-            1,    # max_batch_size
-            50,    # min_subgraph_size
-            PrecisionType.Float32,    # precision
-            False,    # use_static
-            False,    # use_calib_mode
-            )
+    config.enable_tensorrt_engine(1 << 30,  # workspace_size
+                                  1,  # max_batch_size
+                                  50,  # min_subgraph_size
+                                  PrecisionType.Float32,  # precision
+                                  False,  # use_static
+                                  False,  # use_calib_mode
+                                  )
     mean = [0.5, 0.5, 0.5]
     std = [0.5, 0.5, 0.5]
     data = image_preprocess.normalize(img, mean, std)

--- a/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_fcos_dcn_r50_fpn_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_fcos_dcn_r50_fpn_trt_fp32.py
@@ -42,30 +42,30 @@ def inference_fcos_dcn_r50_fpn(img, model_path, params_path):
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
     config.enable_memory_optim()
-    config.enable_tensorrt_engine(1 << 30,    # workspace_size
-            10,    # max_batch_size
-            30,    # min_subgraph_size
-            PrecisionType.Float32,    # precision
-            True,    # use_static
-            False,    # use_calib_mode
-            )
+    config.enable_tensorrt_engine(1 << 30,  # workspace_size
+                                  10,  # max_batch_size
+                                  30,  # min_subgraph_size
+                                  PrecisionType.Float32,  # precision
+                                  True,  # use_static
+                                  False,  # use_calib_mode
+                                  )
     predictor = create_predictor(config)
     input_names = predictor.get_input_names()
-   # input_handle0 = predictor.get_input_handle(input_names[0])
-   # input_handle1 = predictor.get_input_handle(input_names[1])
-   # input_handle2 = predictor.get_input_handle(input_names[2])
+    # input_handle0 = predictor.get_input_handle(input_names[0])
+    # input_handle1 = predictor.get_input_handle(input_names[1])
+    # input_handle2 = predictor.get_input_handle(input_names[2])
 
     im_size = 608
     data = image_preprocess.preprocess(img, im_size)
     scale_factor = np.array([im_size * 1. / img.shape[0], im_size *
-                            1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
+                             1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
     im_shape = np.array([im_size, im_size]).reshape((1, 2)).astype(np.float32)
     data_input = [im_shape, data, scale_factor]
 
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()
@@ -94,7 +94,7 @@ def test_fcos_dcn_r50_fpn():
     test_model = test_gpu_model_jetson(model_name=model_name)
     model_path, params_path = test_model.test_comb_model_path(
         "cv_detect_model")
-    #with_lr_data = inference_yolov3_r50vd(model_path,params_path,ir_optim=True)
+    # with_lr_data = inference_yolov3_r50vd(model_path,params_path,ir_optim=True)
     img_name = 'kite.jpg'
     image_path = test_model.test_readdata(
         path="cv_detect_model", data_name=img_name)

--- a/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_hardnet_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_hardnet_trt_fp32.py
@@ -40,13 +40,13 @@ def inference_hardnet(img, model_path, params_path):
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
     config.enable_memory_optim()
-    config.enable_tensorrt_engine(1 << 30,    # workspace_size
-            1,    # max_batch_size
-            100,    # min_subgraph_size
-            PrecisionType.Float32,    # precision
-            False,    # use_static
-            False,    # use_calib_mode
-            )
+    config.enable_tensorrt_engine(1 << 30,  # workspace_size
+                                  1,  # max_batch_size
+                                  100,  # min_subgraph_size
+                                  PrecisionType.Float32,  # precision
+                                  False,  # use_static
+                                  False,  # use_calib_mode
+                                  )
     mean = [0.5, 0.5, 0.5]
     std = [0.5, 0.5, 0.5]
     data = image_preprocess.normalize(img, mean, std)

--- a/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_ppyolo_r50vd_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_ppyolo_r50vd_trt_fp32.py
@@ -41,27 +41,27 @@ def inference_ppyolo_r50vd(img, model_path, params_path):
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
     config.enable_memory_optim()
-    config.enable_tensorrt_engine(1 << 30,    # workspace_size
-            1,    # max_batch_size
-            50,    # min_subgraph_size
-            PrecisionType.Float32,    # precision
-            False,    # use_static
-            False,    # use_calib_mode
-            )
+    config.enable_tensorrt_engine(1 << 30,  # workspace_size
+                                  1,  # max_batch_size
+                                  50,  # min_subgraph_size
+                                  PrecisionType.Float32,  # precision
+                                  False,  # use_static
+                                  False,  # use_calib_mode
+                                  )
     predictor = create_predictor(config)
     input_names = predictor.get_input_names()
 
     im_size = 608
     data = image_preprocess.preprocess(img, im_size)
     scale_factor = np.array([im_size * 1. / img.shape[0], im_size *
-                            1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
+                             1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
     im_shape = np.array([im_size, im_size]).reshape((1, 2)).astype(np.float32)
     data_input = [im_shape, data, scale_factor]
 
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()
@@ -74,6 +74,7 @@ def inference_ppyolo_r50vd(img, model_path, params_path):
         output_data = output_tensor.copy_to_cpu()
         results.append(output_data)
     return results
+
 
 @pytest.mark.p0
 def test_ppyolo_r50vd():
@@ -89,16 +90,16 @@ def test_ppyolo_r50vd():
     test_model = test_gpu_model_jetson(model_name=model_name)
     model_path, params_path = test_model.test_comb_model_path(
         "cv_detect_model")
-    #with_lr_data = inference_yolov3_r50vd(model_path,params_path,ir_optim=True)
+    # with_lr_data = inference_yolov3_r50vd(model_path,params_path,ir_optim=True)
     img_name = 'kite.jpg'
     image_path = test_model.test_readdata(
         path="cv_detect_model", data_name=img_name)
     img = cv2.imread(image_path)
     with_lr_data = inference_ppyolo_r50vd(img, model_path, params_path)
-    
+
     npy_result = test_model.npy_result_path("cv_detect_model")
     test_model.test_diff(npy_result, with_lr_data[0], diff_standard)
-    
+
     # det image with box
     # np.save("ppyolo_r50vd.npy",with_lr_data[0])
     # image_preprocess.draw_bbox(image_path, with_lr_data[0], save_name="ppyolo_r50vd.jpg")

--- a/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_ppyolov2_r50vd_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_ppyolov2_r50vd_trt_fp32.py
@@ -40,27 +40,27 @@ def inference_ppyolov2_r50vd(img, model_path, params_path):
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
     config.enable_memory_optim()
-    config.enable_tensorrt_engine(1 << 30,    # workspace_size
-            10,    # max_batch_size
-            30,    # min_subgraph_size
-            PrecisionType.Float32,    # precision
-            True,    # use_static
-            False,    # use_calib_mode
-            )
+    config.enable_tensorrt_engine(1 << 30,  # workspace_size
+                                  10,  # max_batch_size
+                                  30,  # min_subgraph_size
+                                  PrecisionType.Float32,  # precision
+                                  True,  # use_static
+                                  False,  # use_calib_mode
+                                  )
     predictor = create_predictor(config)
     input_names = predictor.get_input_names()
 
     im_size = 640
     data = image_preprocess.preprocess(img, im_size)
     scale_factor = np.array([im_size * 1. / img.shape[0], im_size *
-                            1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
+                             1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
     im_shape = np.array([im_size, im_size]).reshape((1, 2)).astype(np.float32)
     data_input = [im_shape, data, scale_factor]
 
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_pspnet_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_pspnet_trt_fp32.py
@@ -40,13 +40,13 @@ def inference_pspnet(img, model_path, params_path):
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
     config.enable_memory_optim()
-    config.enable_tensorrt_engine(1 << 30,    # workspace_size
-            10,    # max_batch_size
-            30,    # min_subgraph_size
-            PrecisionType.Float32,    # precision
-            True,    # use_static
-            False,    # use_calib_mode
-            )
+    config.enable_tensorrt_engine(1 << 30,  # workspace_size
+                                  10,  # max_batch_size
+                                  30,  # min_subgraph_size
+                                  PrecisionType.Float32,  # precision
+                                  True,  # use_static
+                                  False,  # use_calib_mode
+                                  )
     mean = [0.5, 0.5, 0.5]
     std = [0.5, 0.5, 0.5]
     data = image_preprocess.normalize(img, mean, std)

--- a/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_ssd_mobilenet_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_ssd_mobilenet_trt_fp32.py
@@ -39,27 +39,27 @@ def inference_ssd_mobilenet(img, model_path, params_path):
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
     config.enable_memory_optim()
-    config.enable_tensorrt_engine(1 << 30,    # workspace_size
-            1,    # max_batch_size
-            50,    # min_subgraph_size
-            PrecisionType.Float32,    # precision
-            True,    # use_static
-            False,    # use_calib_mode
-            )
+    config.enable_tensorrt_engine(1 << 30,  # workspace_size
+                                  1,  # max_batch_size
+                                  50,  # min_subgraph_size
+                                  PrecisionType.Float32,  # precision
+                                  True,  # use_static
+                                  False,  # use_calib_mode
+                                  )
     predictor = create_predictor(config)
     input_names = predictor.get_input_names()
 
     im_size = 300
     data = image_preprocess.preprocess(img, im_size)
     scale_factor = np.array([im_size * 1. / img.shape[0], im_size *
-                            1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
+                             1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
     im_shape = np.array([im_size, im_size]).reshape((1, 2)).astype(np.float32)
     data_input = [im_shape, data, scale_factor]
 
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()
@@ -98,4 +98,4 @@ def test_ssd_mobilenet():
     test_model.test_diff(npy_result, with_lr_data[0], diff_standard)
 
     # det image with box
-    #image_preprocess.draw_bbox(image_path, with_lr_data[0], save_name="ssd_mobilenet.jpg")
+    # image_preprocess.draw_bbox(image_path, with_lr_data[0], save_name="ssd_mobilenet.jpg")

--- a/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_ssd_vgg16_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_ssd_vgg16_trt_fp32.py
@@ -39,27 +39,27 @@ def inference_ssd_vgg16(img, model_path, params_path):
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
     config.enable_memory_optim()
-    config.enable_tensorrt_engine(1 << 30,    # workspace_size
-            1,    # max_batch_size
-            100,    # min_subgraph_size
-            PrecisionType.Float32,    # precision
-            False,    # use_static
-            False,    # use_calib_mode
-            )
+    config.enable_tensorrt_engine(1 << 30,  # workspace_size
+                                  1,  # max_batch_size
+                                  100,  # min_subgraph_size
+                                  PrecisionType.Float32,  # precision
+                                  False,  # use_static
+                                  False,  # use_calib_mode
+                                  )
     predictor = create_predictor(config)
     input_names = predictor.get_input_names()
 
     im_size = 300
     data = image_preprocess.preprocess(img, im_size)
     scale_factor = np.array([im_size * 1. / img.shape[0], im_size *
-                            1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
+                             1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
     im_shape = np.array([im_size, im_size]).reshape((1, 2)).astype(np.float32)
     data_input = [im_shape, data, scale_factor]
 
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_ttfnet_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_ttfnet_trt_fp32.py
@@ -42,30 +42,30 @@ def inference_ttfnet(img, model_path, params_path):
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
     config.enable_memory_optim()
-    config.enable_tensorrt_engine(1 << 30,    # workspace_size
-            10,    # max_batch_size
-            30,    # min_subgraph_size
-            PrecisionType.Float32,    # precision
-            True,    # use_static
-            False,    # use_calib_mode
-            )
+    config.enable_tensorrt_engine(1 << 30,  # workspace_size
+                                  10,  # max_batch_size
+                                  30,  # min_subgraph_size
+                                  PrecisionType.Float32,  # precision
+                                  True,  # use_static
+                                  False,  # use_calib_mode
+                                  )
     predictor = create_predictor(config)
     input_names = predictor.get_input_names()
-   # input_handle0 = predictor.get_input_handle(input_names[0])
-   # input_handle1 = predictor.get_input_handle(input_names[1])
-   # input_handle2 = predictor.get_input_handle(input_names[2])
+    # input_handle0 = predictor.get_input_handle(input_names[0])
+    # input_handle1 = predictor.get_input_handle(input_names[1])
+    # input_handle2 = predictor.get_input_handle(input_names[2])
 
     im_size = 512
     data = image_preprocess.preprocess(img, im_size)
     scale_factor = np.array([im_size * 1. / img.shape[0], im_size *
-                            1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
+                             1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
     im_shape = np.array([im_size, im_size]).reshape((1, 2)).astype(np.float32)
     data_input = [data, scale_factor]
 
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()
@@ -94,7 +94,7 @@ def test_ttfnet():
     test_model = test_gpu_model_jetson(model_name=model_name)
     model_path, params_path = test_model.test_comb_model_path(
         "cv_detect_model")
-    #with_lr_data = inference_yolov3_r50vd(model_path,params_path,ir_optim=True)
+    # with_lr_data = inference_yolov3_r50vd(model_path,params_path,ir_optim=True)
     img_name = 'kite.jpg'
     image_path = test_model.test_readdata(
         path="cv_detect_model", data_name=img_name)
@@ -104,4 +104,4 @@ def test_ttfnet():
     test_model.test_diff(npy_result, with_lr_data[0], diff_standard)
 
     # det image with box
-    #image_preprocess.draw_bbox(img_name, without_lr_data[0], save_name="ttfnet.jpg")
+    # image_preprocess.draw_bbox(img_name, without_lr_data[0], save_name="ttfnet.jpg")

--- a/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_unet_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_unet_trt_fp32.py
@@ -22,6 +22,7 @@ from paddle.inference import PrecisionType
 from paddle.inference import create_predictor
 from test_src import test_gpu_model_jetson
 
+
 def inference_unet(img, model_path, params_path):
     """
     inference_unet
@@ -39,16 +40,16 @@ def inference_unet(img, model_path, params_path):
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
     config.enable_memory_optim()
-    config.enable_tensorrt_engine(1 << 30,    # workspace_size
-            1,    # max_batch_size
-            30,    # min_subgraph_size
-            PrecisionType.Float32,    # precision
-            False,    # use_static
-            False,    # use_calib_mode
-            )
+    config.enable_tensorrt_engine(1 << 30,  # workspace_size
+                                  1,  # max_batch_size
+                                  30,  # min_subgraph_size
+                                  PrecisionType.Float32,  # precision
+                                  False,  # use_static
+                                  False,  # use_calib_mode
+                                  )
     mean = [0.5, 0.5, 0.5]
     std = [0.5, 0.5, 0.5]
-    data = image_preprocess.normalize(img,mean,std)
+    data = image_preprocess.normalize(img, mean, std)
     data_input = np.array([data]).transpose([0, 3, 1, 2])
 
     predictor = create_predictor(config)
@@ -65,6 +66,7 @@ def inference_unet(img, model_path, params_path):
     output_data = output_handle.copy_to_cpu()
 
     return output_data
+
 
 @pytest.mark.p0
 @pytest.mark.p1
@@ -87,7 +89,7 @@ def test_unet():
     with_lr_data = inference_unet(img, model_path, params_path)
     npy_result = test_model.npy_result_path("cv_seg_model")
     test_model.test_diff(npy_result, with_lr_data[0], diff_standard)
-    
+
     # save color img
     # np.save("unet.npy",with_lr_data[0]) 
     # imgs = np.argmax(with_lr_data[0], axis=0)

--- a/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_yolov3_darknet53_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_yolov3_darknet53_trt_fp32.py
@@ -41,27 +41,27 @@ def inference_yolov3_darknet53(img, model_path, params_path):
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
     config.enable_memory_optim()
-    config.enable_tensorrt_engine(1 << 30,    # workspace_size
-            10,    # max_batch_size
-            30,    # min_subgraph_size
-            PrecisionType.Float32,    # precision
-            True,    # use_static
-            False,    # use_calib_mode
-            )
+    config.enable_tensorrt_engine(1 << 30,  # workspace_size
+                                  10,  # max_batch_size
+                                  30,  # min_subgraph_size
+                                  PrecisionType.Float32,  # precision
+                                  True,  # use_static
+                                  False,  # use_calib_mode
+                                  )
     predictor = create_predictor(config)
     input_names = predictor.get_input_names()
 
     im_size = 608
     data = image_preprocess.preprocess(img, im_size)
     scale_factor = np.array([im_size * 1. / img.shape[0], im_size *
-                            1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
+                             1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
     im_shape = np.array([im_size, im_size]).reshape((1, 2)).astype(np.float32)
     data_input = [im_shape, data, scale_factor]
 
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()
@@ -90,7 +90,7 @@ def test_yolov3_darknet53():
     test_model = test_gpu_model_jetson(model_name=model_name)
     model_path, params_path = test_model.test_comb_model_path(
         "cv_detect_model")
-    #with_lr_data = inference_yolov3_r50vd(model_path,params_path,ir_optim=True)
+    # with_lr_data = inference_yolov3_r50vd(model_path,params_path,ir_optim=True)
     img_name = 'kite.jpg'
     image_path = test_model.test_readdata(
         path="cv_detect_model", data_name=img_name)

--- a/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_yolov3_mobilenet_v1_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_yolov3_mobilenet_v1_trt_fp32.py
@@ -41,27 +41,27 @@ def inference_yolov3_mobilenet_v1(img, model_path, params_path):
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
     config.enable_memory_optim()
-    config.enable_tensorrt_engine(1 << 30,    # workspace_size
-            10,    # max_batch_size
-            30,    # min_subgraph_size
-            PrecisionType.Float32,    # precision
-            True,    # use_static
-            False,    # use_calib_mode
-            )
+    config.enable_tensorrt_engine(1 << 30,  # workspace_size
+                                  10,  # max_batch_size
+                                  30,  # min_subgraph_size
+                                  PrecisionType.Float32,  # precision
+                                  True,  # use_static
+                                  False,  # use_calib_mode
+                                  )
     predictor = create_predictor(config)
     input_names = predictor.get_input_names()
 
     im_size = 608
     data = image_preprocess.preprocess(img, im_size)
     scale_factor = np.array([im_size * 1. / img.shape[0], im_size *
-                            1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
+                             1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
     im_shape = np.array([im_size, im_size]).reshape((1, 2)).astype(np.float32)
     data_input = [im_shape, data, scale_factor]
 
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()
@@ -90,7 +90,7 @@ def test_yolov3_mobilenet_v1():
     test_model = test_gpu_model_jetson(model_name=model_name)
     model_path, params_path = test_model.test_comb_model_path(
         "cv_detect_model")
-    #with_lr_data = inference_yolov3_mobilenet_v1(model_path,params_path,ir_optim=True)
+    # with_lr_data = inference_yolov3_mobilenet_v1(model_path,params_path,ir_optim=True)
     img_name = 'kite.jpg'
     image_path = test_model.test_readdata(
         path="cv_detect_model", data_name=img_name)

--- a/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_yolov3_r50vd_trt_fp32.py
+++ b/inference/inference_api_test/python_api_test/tests/trt_fp32/test_v1_yolov3_r50vd_trt_fp32.py
@@ -41,27 +41,27 @@ def inference_yolov3_r50vd(img, model_path, params_path):
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
     config.enable_memory_optim()
-    config.enable_tensorrt_engine(1 << 30,    # workspace_size
-            10,    # max_batch_size
-            30,    # min_subgraph_size
-            PrecisionType.Half,    # precision
-            True,    # use_static
-            False,    # use_calib_mode
-            )
+    config.enable_tensorrt_engine(1 << 30,  # workspace_size
+                                  10,  # max_batch_size
+                                  30,  # min_subgraph_size
+                                  PrecisionType.Half,  # precision
+                                  True,  # use_static
+                                  False,  # use_calib_mode
+                                  )
     predictor = create_predictor(config)
     input_names = predictor.get_input_names()
 
     im_size = 608
     data = image_preprocess.preprocess(img, im_size)
     scale_factor = np.array([im_size * 1. / img.shape[0], im_size *
-                            1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
+                             1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
     im_shape = np.array([im_size, im_size]).reshape((1, 2)).astype(np.float32)
     data_input = [im_shape, data, scale_factor]
 
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()
@@ -74,6 +74,7 @@ def inference_yolov3_r50vd(img, model_path, params_path):
         output_data = output_tensor.copy_to_cpu()
         results.append(output_data)
     return results
+
 
 @pytest.mark.p0
 def test_yolov3_r50vd():
@@ -89,7 +90,7 @@ def test_yolov3_r50vd():
     test_model = test_gpu_model_jetson(model_name=model_name)
     model_path, params_path = test_model.test_comb_model_path(
         "cv_detect_model")
-    #with_lr_data = inference_yolov3_r50vd(model_path,params_path,ir_optim=True)
+    # with_lr_data = inference_yolov3_r50vd(model_path,params_path,ir_optim=True)
     img_name = 'kite.jpg'
     image_path = test_model.test_readdata(
         path="cv_detect_model", data_name=img_name)
@@ -97,7 +98,7 @@ def test_yolov3_r50vd():
     with_lr_data = inference_yolov3_r50vd(img, model_path, params_path)
     npy_result = test_model.npy_result_path("cv_detect_model")
     test_model.test_diff(npy_result, with_lr_data[0], diff_standard)
-    
+
     # det image with box
     # np.save("yolov3_r50vd.npy",with_lr_data[0])
     # image_preprocess.draw_bbox(

--- a/inference/inference_api_test/python_api_test/tests/xpu/xpu_AlexNet_test.py
+++ b/inference/inference_api_test/python_api_test/tests/xpu/xpu_AlexNet_test.py
@@ -36,7 +36,7 @@ def inference_AlexNet(img, model_path, params_path):
     """
     config = Config(model_path, params_path)
     config.enable_xpu(10 * 1024 * 1024)
-    config.enable_lite_engine(PrecisionType.Float32, True) 
+    config.enable_lite_engine(PrecisionType.Float32, True)
     config.switch_ir_optim(True)
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
@@ -51,7 +51,7 @@ def inference_AlexNet(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()
@@ -64,7 +64,8 @@ def inference_AlexNet(img, model_path, params_path):
         output_data = output_tensor.copy_to_cpu()
         results.append(output_data)
     return results
-    
+
+
 @pytest.mark.p0
 def test_AlexNet():
     """
@@ -89,5 +90,3 @@ def test_AlexNet():
     # for test images class 
     # np.save("AlexNet.npy",with_lr_data[0])
     # print(np.argmax(with_lr_data[0][0]))
-
-

--- a/inference/inference_api_test/python_api_test/tests/xpu/xpu_DPN68_test.py
+++ b/inference/inference_api_test/python_api_test/tests/xpu/xpu_DPN68_test.py
@@ -36,7 +36,7 @@ def inference_DPN68(img, model_path, params_path):
     """
     config = Config(model_path, params_path)
     config.enable_xpu(10 * 1024 * 1024)
-    config.enable_lite_engine(PrecisionType.Float32, True) 
+    config.enable_lite_engine(PrecisionType.Float32, True)
     config.switch_ir_optim(True)
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
@@ -51,7 +51,7 @@ def inference_DPN68(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/xpu/xpu_DarkNet53_test.py
+++ b/inference/inference_api_test/python_api_test/tests/xpu/xpu_DarkNet53_test.py
@@ -51,7 +51,7 @@ def inference_DarkNet53(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/xpu/xpu_DenseNet121_test.py
+++ b/inference/inference_api_test/python_api_test/tests/xpu/xpu_DenseNet121_test.py
@@ -36,7 +36,7 @@ def inference_DenseNet121(img, model_path, params_path):
     """
     config = Config(model_path, params_path)
     config.enable_xpu(10 * 1024 * 1024)
-    config.enable_lite_engine(PrecisionType.Float32, True) 
+    config.enable_lite_engine(PrecisionType.Float32, True)
     config.switch_ir_optim(True)
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
@@ -51,7 +51,7 @@ def inference_DenseNet121(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/xpu/xpu_EfficientNetB0_test.py
+++ b/inference/inference_api_test/python_api_test/tests/xpu/xpu_EfficientNetB0_test.py
@@ -36,7 +36,7 @@ def inference_EfficientNetB0(img, model_path, params_path):
     """
     config = Config(model_path, params_path)
     config.enable_xpu(10 * 1024 * 1024)
-    config.enable_lite_engine(PrecisionType.Float32, True) 
+    config.enable_lite_engine(PrecisionType.Float32, True)
     config.switch_ir_optim(True)
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
@@ -51,7 +51,7 @@ def inference_EfficientNetB0(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/xpu/xpu_GhostNet_x1_3_test.py
+++ b/inference/inference_api_test/python_api_test/tests/xpu/xpu_GhostNet_x1_3_test.py
@@ -36,7 +36,7 @@ def inference_GhostNet_x1_3(img, model_path, params_path):
     """
     config = Config(model_path, params_path)
     config.enable_xpu(10 * 1024 * 1024)
-    config.enable_lite_engine(PrecisionType.Float32, True) 
+    config.enable_lite_engine(PrecisionType.Float32, True)
     config.switch_ir_optim(True)
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
@@ -51,7 +51,7 @@ def inference_GhostNet_x1_3(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/xpu/xpu_GoogLeNet_test.py
+++ b/inference/inference_api_test/python_api_test/tests/xpu/xpu_GoogLeNet_test.py
@@ -36,7 +36,7 @@ def inference_GoogLeNet(img, model_path, params_path):
     """
     config = Config(model_path, params_path)
     config.enable_xpu(10 * 1024 * 1024)
-    config.enable_lite_engine(PrecisionType.Float32, True) 
+    config.enable_lite_engine(PrecisionType.Float32, True)
     config.switch_ir_optim(True)
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
@@ -51,7 +51,7 @@ def inference_GoogLeNet(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()
@@ -64,7 +64,8 @@ def inference_GoogLeNet(img, model_path, params_path):
         output_data = output_tensor.copy_to_cpu()
         results.append(output_data)
     return results
-    
+
+
 @pytest.mark.p0
 def test_GoogLeNet():
     """
@@ -89,4 +90,3 @@ def test_GoogLeNet():
     # for test
     # np.save("GoogLeNet.npy",with_lr_data[0])
     # print(np.argmax(with_lr_data[0][0]))
-

--- a/inference/inference_api_test/python_api_test/tests/xpu/xpu_HRNet_W18_C_test.py
+++ b/inference/inference_api_test/python_api_test/tests/xpu/xpu_HRNet_W18_C_test.py
@@ -51,7 +51,7 @@ def inference_HRNet_W18_C(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/xpu/xpu_InceptionV4_test.py
+++ b/inference/inference_api_test/python_api_test/tests/xpu/xpu_InceptionV4_test.py
@@ -36,7 +36,7 @@ def inference_InceptionV4(img, model_path, params_path):
     """
     config = Config(model_path, params_path)
     config.enable_xpu(10 * 1024 * 1024)
-    config.enable_lite_engine(PrecisionType.Float32, True) 
+    config.enable_lite_engine(PrecisionType.Float32, True)
     config.switch_ir_optim(True)
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
@@ -51,7 +51,7 @@ def inference_InceptionV4(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()
@@ -64,7 +64,8 @@ def inference_InceptionV4(img, model_path, params_path):
         output_data = output_tensor.copy_to_cpu()
         results.append(output_data)
     return results
-    
+
+
 @pytest.mark.p0
 def test_InceptionV4():
     """
@@ -85,8 +86,7 @@ def test_InceptionV4():
     with_lr_data = inference_InceptionV4(img, model_path, params_path)
     npy_result = test_model.npy_result_path("cv_class_model")
     test_model.test_diff(npy_result, with_lr_data[0], diff_standard)
-    
+
     # for test
     # np.save("InceptionV4.npy",with_lr_data[0])
     # print(np.argmax(with_lr_data[0][0]))
-

--- a/inference/inference_api_test/python_api_test/tests/xpu/xpu_MobileNetV1_test.py
+++ b/inference/inference_api_test/python_api_test/tests/xpu/xpu_MobileNetV1_test.py
@@ -36,7 +36,7 @@ def inference_MobileNetV1(img, model_path, params_path):
     """
     config = Config(model_path, params_path)
     config.enable_xpu(10 * 1024 * 1024)
-    config.enable_lite_engine(PrecisionType.Float32, True) 
+    config.enable_lite_engine(PrecisionType.Float32, True)
     config.switch_ir_optim(True)
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
@@ -51,7 +51,7 @@ def inference_MobileNetV1(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()
@@ -64,7 +64,8 @@ def inference_MobileNetV1(img, model_path, params_path):
         output_data = output_tensor.copy_to_cpu()
         results.append(output_data)
     return results
-    
+
+
 @pytest.mark.p0
 def test_MobileNetV1():
     """
@@ -85,8 +86,7 @@ def test_MobileNetV1():
     with_lr_data = inference_MobileNetV1(img, model_path, params_path)
     npy_result = test_model.npy_result_path("cv_class_model")
     test_model.test_diff(npy_result, with_lr_data[0], diff_standard)
-    
+
     # for test
     # np.save("MobileNetV1.npy",with_lr_data[0])
     # print(np.argmax(with_lr_data[0][0]))
-

--- a/inference/inference_api_test/python_api_test/tests/xpu/xpu_MobileNetV2_test.py
+++ b/inference/inference_api_test/python_api_test/tests/xpu/xpu_MobileNetV2_test.py
@@ -36,7 +36,7 @@ def inference_MobileNetV2(img, model_path, params_path):
     """
     config = Config(model_path, params_path)
     config.enable_xpu(10 * 1024 * 1024)
-    config.enable_lite_engine(PrecisionType.Float32, True) 
+    config.enable_lite_engine(PrecisionType.Float32, True)
     config.switch_ir_optim(True)
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
@@ -51,7 +51,7 @@ def inference_MobileNetV2(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/xpu/xpu_MobileNetV3_large_test.py
+++ b/inference/inference_api_test/python_api_test/tests/xpu/xpu_MobileNetV3_large_test.py
@@ -36,7 +36,7 @@ def inference_MobileNetV3_large(img, model_path, params_path):
     """
     config = Config(model_path, params_path)
     config.enable_xpu(10 * 1024 * 1024)
-    config.enable_lite_engine(PrecisionType.Float32, True) 
+    config.enable_lite_engine(PrecisionType.Float32, True)
     config.switch_ir_optim(True)
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
@@ -51,7 +51,7 @@ def inference_MobileNetV3_large(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/xpu/xpu_RegNetX_4GF_test.py
+++ b/inference/inference_api_test/python_api_test/tests/xpu/xpu_RegNetX_4GF_test.py
@@ -36,7 +36,7 @@ def inference_RegNetX_4GF(img, model_path, params_path):
     """
     config = Config(model_path, params_path)
     config.enable_xpu(10 * 1024 * 1024)
-    config.enable_lite_engine(PrecisionType.Float32, True) 
+    config.enable_lite_engine(PrecisionType.Float32, True)
     config.switch_ir_optim(True)
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
@@ -51,7 +51,7 @@ def inference_RegNetX_4GF(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/xpu/xpu_Res2Net50_test.py
+++ b/inference/inference_api_test/python_api_test/tests/xpu/xpu_Res2Net50_test.py
@@ -36,7 +36,7 @@ def inference_Res2Net50(img, model_path, params_path):
     """
     config = Config(model_path, params_path)
     config.enable_xpu(10 * 1024 * 1024)
-    config.enable_lite_engine(PrecisionType.Float32, True) 
+    config.enable_lite_engine(PrecisionType.Float32, True)
     config.switch_ir_optim(True)
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
@@ -51,7 +51,7 @@ def inference_Res2Net50(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/xpu/xpu_ResNeSt50_fast_test.py
+++ b/inference/inference_api_test/python_api_test/tests/xpu/xpu_ResNeSt50_fast_test.py
@@ -36,7 +36,7 @@ def inference_ResNeSt50_fast(img, model_path, params_path):
     """
     config = Config(model_path, params_path)
     config.enable_xpu(10 * 1024 * 1024)
-    config.enable_lite_engine(PrecisionType.Float32, True) 
+    config.enable_lite_engine(PrecisionType.Float32, True)
     config.switch_ir_optim(True)
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
@@ -51,7 +51,7 @@ def inference_ResNeSt50_fast(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/xpu/xpu_ResNet50_test.py
+++ b/inference/inference_api_test/python_api_test/tests/xpu/xpu_ResNet50_test.py
@@ -36,7 +36,7 @@ def inference_ResNet50(img, model_path, params_path):
     """
     config = Config(model_path, params_path)
     config.enable_xpu(10 * 1024 * 1024)
-    config.enable_lite_engine(PrecisionType.Float32, True) 
+    config.enable_lite_engine(PrecisionType.Float32, True)
     config.switch_ir_optim(True)
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
@@ -51,7 +51,7 @@ def inference_ResNet50(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/xpu/xpu_ResNet50_vd_test.py
+++ b/inference/inference_api_test/python_api_test/tests/xpu/xpu_ResNet50_vd_test.py
@@ -36,7 +36,7 @@ def inference_ResNet50_vd(img, model_path, params_path):
     """
     config = Config(model_path, params_path)
     config.enable_xpu(10 * 1024 * 1024)
-    config.enable_lite_engine(PrecisionType.Float32, True) 
+    config.enable_lite_engine(PrecisionType.Float32, True)
     config.switch_ir_optim(True)
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
@@ -51,7 +51,7 @@ def inference_ResNet50_vd(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/xpu/xpu_SE_ResNeXt50_test.py
+++ b/inference/inference_api_test/python_api_test/tests/xpu/xpu_SE_ResNeXt50_test.py
@@ -36,7 +36,7 @@ def inference_SE_ResNeXt50(img, model_path, params_path):
     """
     config = Config(model_path, params_path)
     config.enable_xpu(10 * 1024 * 1024)
-    config.enable_lite_engine(PrecisionType.Float32, True) 
+    config.enable_lite_engine(PrecisionType.Float32, True)
     config.switch_ir_optim(True)
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
@@ -51,7 +51,7 @@ def inference_SE_ResNeXt50(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/xpu/xpu_ShuffleNetV2_test.py
+++ b/inference/inference_api_test/python_api_test/tests/xpu/xpu_ShuffleNetV2_test.py
@@ -36,7 +36,7 @@ def inference_ShuffleNetV2(img, model_path, params_path):
     """
     config = Config(model_path, params_path)
     config.enable_xpu(10 * 1024 * 1024)
-    config.enable_lite_engine(PrecisionType.Float32, True) 
+    config.enable_lite_engine(PrecisionType.Float32, True)
     config.switch_ir_optim(True)
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
@@ -51,7 +51,7 @@ def inference_ShuffleNetV2(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/xpu/xpu_SqueezeNet1_test.py
+++ b/inference/inference_api_test/python_api_test/tests/xpu/xpu_SqueezeNet1_test.py
@@ -36,7 +36,7 @@ def inference_SqueezeNet1(img, model_path, params_path):
     """
     config = Config(model_path, params_path)
     config.enable_xpu(10 * 1024 * 1024)
-    config.enable_lite_engine(PrecisionType.Float32, True) 
+    config.enable_lite_engine(PrecisionType.Float32, True)
     config.switch_ir_optim(True)
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
@@ -51,7 +51,7 @@ def inference_SqueezeNet1(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/xpu/xpu_VGG11_test.py
+++ b/inference/inference_api_test/python_api_test/tests/xpu/xpu_VGG11_test.py
@@ -36,7 +36,7 @@ def inference_VGG11(img, model_path, params_path):
     """
     config = Config(model_path, params_path)
     config.enable_xpu(10 * 1024 * 1024)
-    config.enable_lite_engine(PrecisionType.Float32, True) 
+    config.enable_lite_engine(PrecisionType.Float32, True)
     config.switch_ir_optim(True)
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
@@ -51,7 +51,7 @@ def inference_VGG11(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/xpu/xpu_Xception41_test.py
+++ b/inference/inference_api_test/python_api_test/tests/xpu/xpu_Xception41_test.py
@@ -36,7 +36,7 @@ def inference_Xception41(img, model_path, params_path):
     """
     config = Config(model_path, params_path)
     config.enable_xpu(10 * 1024 * 1024)
-    config.enable_lite_engine(PrecisionType.Float32, True) 
+    config.enable_lite_engine(PrecisionType.Float32, True)
     config.switch_ir_optim(True)
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
@@ -51,7 +51,7 @@ def inference_Xception41(img, model_path, params_path):
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/xpu/xpu_deeplabv3_resnet50_test.py
+++ b/inference/inference_api_test/python_api_test/tests/xpu/xpu_deeplabv3_resnet50_test.py
@@ -23,6 +23,7 @@ from paddle.inference import create_predictor
 
 from test_src import test_gpu_model_jetson
 
+
 def inference_deeplabv3_resnet50(img, model_path, params_path):
     """
     inference_deeplabv3_resnet50
@@ -44,7 +45,7 @@ def inference_deeplabv3_resnet50(img, model_path, params_path):
 
     mean = [0.5, 0.5, 0.5]
     std = [0.5, 0.5, 0.5]
-    data = image_preprocess.normalize(img,mean,std)
+    data = image_preprocess.normalize(img, mean, std)
     data_input = np.array([data]).transpose([0, 3, 1, 2])
 
     predictor = create_predictor(config)
@@ -61,6 +62,7 @@ def inference_deeplabv3_resnet50(img, model_path, params_path):
     output_data = output_handle.copy_to_cpu()
 
     return output_data
+
 
 @pytest.mark.p0
 @pytest.mark.p1

--- a/inference/inference_api_test/python_api_test/tests/xpu/xpu_deeplabv3p_resnet50_test.py
+++ b/inference/inference_api_test/python_api_test/tests/xpu/xpu_deeplabv3p_resnet50_test.py
@@ -22,6 +22,7 @@ from paddle.inference import PrecisionType
 from paddle.inference import create_predictor
 from test_src import test_gpu_model_jetson
 
+
 def inference_deeplabv3p_resnet50(img, model_path, params_path):
     """
     inference_deeplabv3p_resnet50
@@ -43,7 +44,7 @@ def inference_deeplabv3p_resnet50(img, model_path, params_path):
 
     mean = [0.5, 0.5, 0.5]
     std = [0.5, 0.5, 0.5]
-    data = image_preprocess.normalize(img,mean,std)
+    data = image_preprocess.normalize(img, mean, std)
     data_input = np.array([data]).transpose([0, 3, 1, 2])
 
     predictor = create_predictor(config)
@@ -60,6 +61,7 @@ def inference_deeplabv3p_resnet50(img, model_path, params_path):
     output_data = output_handle.copy_to_cpu()
 
     return output_data
+
 
 @pytest.mark.p0
 @pytest.mark.p1

--- a/inference/inference_api_test/python_api_test/tests/xpu/xpu_faster_rcnn_r50_test.py
+++ b/inference/inference_api_test/python_api_test/tests/xpu/xpu_faster_rcnn_r50_test.py
@@ -38,7 +38,7 @@ def inference_faster_rcnn_r50(img, model_path, params_path):
     batch_size = 1
     config = Config(model_path, params_path)
     config.enable_xpu(10 * 1024 * 1024)
-    config.enable_lite_engine(PrecisionType.Float32, True) 
+    config.enable_lite_engine(PrecisionType.Float32, True)
     config.switch_ir_optim(True)
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
@@ -46,21 +46,21 @@ def inference_faster_rcnn_r50(img, model_path, params_path):
 
     predictor = create_predictor(config)
     input_names = predictor.get_input_names()
-   # input_handle0 = predictor.get_input_handle(input_names[0])
-   # input_handle1 = predictor.get_input_handle(input_names[1])
-   # input_handle2 = predictor.get_input_handle(input_names[2])
+    # input_handle0 = predictor.get_input_handle(input_names[0])
+    # input_handle1 = predictor.get_input_handle(input_names[1])
+    # input_handle2 = predictor.get_input_handle(input_names[2])
 
     im_size = 608
     data = image_preprocess.preprocess(img, im_size)
     scale_factor = np.array([im_size * 1. / img.shape[0], im_size *
-                            1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
+                             1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
     im_shape = np.array([im_size, im_size]).reshape((1, 2)).astype(np.float32)
     data_input = [im_shape, data, scale_factor]
 
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()
@@ -89,7 +89,7 @@ def test_faster_rcnn_r50():
     test_model = test_gpu_model_jetson(model_name=model_name)
     model_path, params_path = test_model.test_comb_model_path(
         "cv_detect_model")
-    #with_lr_data = inference_yolov3_r50vd(model_path,params_path,ir_optim=True)
+    # with_lr_data = inference_yolov3_r50vd(model_path,params_path,ir_optim=True)
     img_name = 'kite.jpg'
     image_path = test_model.test_readdata(
         path="cv_detect_model", data_name=img_name)

--- a/inference/inference_api_test/python_api_test/tests/xpu/xpu_fcn_hrnetw18_test.py
+++ b/inference/inference_api_test/python_api_test/tests/xpu/xpu_fcn_hrnetw18_test.py
@@ -36,7 +36,7 @@ def inference_fcn_hrnetw18(img, model_path, params_path):
     batch_size = 1
     config = Config(model_path, params_path)
     config.enable_xpu(10 * 1024 * 1024)
-    config.enable_lite_engine(PrecisionType.Float32, True) 
+    config.enable_lite_engine(PrecisionType.Float32, True)
     config.switch_ir_optim(True)
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)

--- a/inference/inference_api_test/python_api_test/tests/xpu/xpu_fcos_dcn_r50_fpn_test.py
+++ b/inference/inference_api_test/python_api_test/tests/xpu/xpu_fcos_dcn_r50_fpn_test.py
@@ -38,7 +38,7 @@ def inference_fcos_dcn_r50_fpn(img, model_path, params_path):
     batch_size = 1
     config = Config(model_path, params_path)
     config.enable_xpu(10 * 1024 * 1024)
-    config.enable_lite_engine(PrecisionType.Float32, True) 
+    config.enable_lite_engine(PrecisionType.Float32, True)
     config.switch_ir_optim(True)
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
@@ -46,21 +46,21 @@ def inference_fcos_dcn_r50_fpn(img, model_path, params_path):
 
     predictor = create_predictor(config)
     input_names = predictor.get_input_names()
-   # input_handle0 = predictor.get_input_handle(input_names[0])
-   # input_handle1 = predictor.get_input_handle(input_names[1])
-   # input_handle2 = predictor.get_input_handle(input_names[2])
+    # input_handle0 = predictor.get_input_handle(input_names[0])
+    # input_handle1 = predictor.get_input_handle(input_names[1])
+    # input_handle2 = predictor.get_input_handle(input_names[2])
 
     im_size = 608
     data = image_preprocess.preprocess(img, im_size)
     scale_factor = np.array([im_size * 1. / img.shape[0], im_size *
-                            1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
+                             1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
     im_shape = np.array([im_size, im_size]).reshape((1, 2)).astype(np.float32)
     data_input = [im_shape, data, scale_factor]
 
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()
@@ -89,7 +89,7 @@ def test_fcos_dcn_r50_fpn():
     test_model = test_gpu_model_jetson(model_name=model_name)
     model_path, params_path = test_model.test_comb_model_path(
         "cv_detect_model")
-    #with_lr_data = inference_yolov3_r50vd(model_path,params_path,ir_optim=True)
+    # with_lr_data = inference_yolov3_r50vd(model_path,params_path,ir_optim=True)
     img_name = 'kite.jpg'
     image_path = test_model.test_readdata(
         path="cv_detect_model", data_name=img_name)

--- a/inference/inference_api_test/python_api_test/tests/xpu/xpu_hardnet_test.py
+++ b/inference/inference_api_test/python_api_test/tests/xpu/xpu_hardnet_test.py
@@ -36,7 +36,7 @@ def inference_hardnet(img, model_path, params_path):
     batch_size = 1
     config = Config(model_path, params_path)
     config.enable_xpu(10 * 1024 * 1024)
-    config.enable_lite_engine(PrecisionType.Float32, True) 
+    config.enable_lite_engine(PrecisionType.Float32, True)
     config.switch_ir_optim(True)
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)

--- a/inference/inference_api_test/python_api_test/tests/xpu/xpu_ppyolo_r50vd_test.py
+++ b/inference/inference_api_test/python_api_test/tests/xpu/xpu_ppyolo_r50vd_test.py
@@ -37,7 +37,7 @@ def inference_ppyolo_r50vd(img, model_path, params_path):
     batch_size = 1
     config = Config(model_path, params_path)
     config.enable_xpu(10 * 1024 * 1024)
-    config.enable_lite_engine(PrecisionType.Float32, True) 
+    config.enable_lite_engine(PrecisionType.Float32, True)
     config.switch_ir_optim(True)
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
@@ -49,14 +49,14 @@ def inference_ppyolo_r50vd(img, model_path, params_path):
     im_size = 608
     data = image_preprocess.preprocess(img, im_size)
     scale_factor = np.array([im_size * 1. / img.shape[0], im_size *
-                            1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
+                             1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
     im_shape = np.array([im_size, im_size]).reshape((1, 2)).astype(np.float32)
     data_input = [im_shape, data, scale_factor]
 
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()
@@ -69,6 +69,7 @@ def inference_ppyolo_r50vd(img, model_path, params_path):
         output_data = output_tensor.copy_to_cpu()
         results.append(output_data)
     return results
+
 
 @pytest.mark.p0
 def test_ppyolo_r50vd():
@@ -84,16 +85,16 @@ def test_ppyolo_r50vd():
     test_model = test_gpu_model_jetson(model_name=model_name)
     model_path, params_path = test_model.test_comb_model_path(
         "cv_detect_model")
-    #with_lr_data = inference_yolov3_r50vd(model_path,params_path,ir_optim=True)
+    # with_lr_data = inference_yolov3_r50vd(model_path,params_path,ir_optim=True)
     img_name = 'kite.jpg'
     image_path = test_model.test_readdata(
         path="cv_detect_model", data_name=img_name)
     img = cv2.imread(image_path)
     with_lr_data = inference_ppyolo_r50vd(img, model_path, params_path)
-    
+
     npy_result = test_model.npy_result_path("cv_detect_model")
     test_model.test_diff(npy_result, with_lr_data[0], diff_standard)
-    
+
     # det image with box
     # np.save("ppyolo_r50vd.npy",with_lr_data[0])
     # image_preprocess.draw_bbox(image_path, with_lr_data[0], save_name="ppyolo_r50vd.jpg")

--- a/inference/inference_api_test/python_api_test/tests/xpu/xpu_ppyolov2_r50vd_test.py
+++ b/inference/inference_api_test/python_api_test/tests/xpu/xpu_ppyolov2_r50vd_test.py
@@ -36,7 +36,7 @@ def inference_ppyolov2_r50vd(img, model_path, params_path):
     batch_size = 1
     config = Config(model_path, params_path)
     config.enable_xpu(10 * 1024 * 1024)
-    config.enable_lite_engine(PrecisionType.Float32, True) 
+    config.enable_lite_engine(PrecisionType.Float32, True)
     config.switch_ir_optim(True)
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
@@ -48,14 +48,14 @@ def inference_ppyolov2_r50vd(img, model_path, params_path):
     im_size = 640
     data = image_preprocess.preprocess(img, im_size)
     scale_factor = np.array([im_size * 1. / img.shape[0], im_size *
-                            1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
+                             1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
     im_shape = np.array([im_size, im_size]).reshape((1, 2)).astype(np.float32)
     data_input = [im_shape, data, scale_factor]
 
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/xpu/xpu_ssd_mobilenet_test.py
+++ b/inference/inference_api_test/python_api_test/tests/xpu/xpu_ssd_mobilenet_test.py
@@ -35,7 +35,7 @@ def inference_ssd_mobilenet(img, model_path, params_path):
     """
     config = Config(model_path, params_path)
     config.enable_xpu(10 * 1024 * 1024)
-    config.enable_lite_engine(PrecisionType.Float32, True) 
+    config.enable_lite_engine(PrecisionType.Float32, True)
     config.switch_ir_optim(True)
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
@@ -47,14 +47,14 @@ def inference_ssd_mobilenet(img, model_path, params_path):
     im_size = 300
     data = image_preprocess.preprocess(img, im_size)
     scale_factor = np.array([im_size * 1. / img.shape[0], im_size *
-                            1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
+                             1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
     im_shape = np.array([im_size, im_size]).reshape((1, 2)).astype(np.float32)
     data_input = [im_shape, data, scale_factor]
 
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()
@@ -93,4 +93,4 @@ def test_ssd_mobilenet():
     test_model.test_diff(npy_result, with_lr_data[0], diff_standard)
 
     # det image with box
-    #image_preprocess.draw_bbox(image_path, with_lr_data[0], save_name="ssd_mobilenet.jpg")
+    # image_preprocess.draw_bbox(image_path, with_lr_data[0], save_name="ssd_mobilenet.jpg")

--- a/inference/inference_api_test/python_api_test/tests/xpu/xpu_ssd_vgg16_test.py
+++ b/inference/inference_api_test/python_api_test/tests/xpu/xpu_ssd_vgg16_test.py
@@ -35,7 +35,7 @@ def inference_ssd_vgg16(img, model_path, params_path):
     """
     config = Config(model_path, params_path)
     config.enable_xpu(10 * 1024 * 1024)
-    config.enable_lite_engine(PrecisionType.Float32, True) 
+    config.enable_lite_engine(PrecisionType.Float32, True)
     config.switch_ir_optim(True)
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
@@ -47,14 +47,14 @@ def inference_ssd_vgg16(img, model_path, params_path):
     im_size = 300
     data = image_preprocess.preprocess(img, im_size)
     scale_factor = np.array([im_size * 1. / img.shape[0], im_size *
-                            1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
+                             1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
     im_shape = np.array([im_size, im_size]).reshape((1, 2)).astype(np.float32)
     data_input = [im_shape, data, scale_factor]
 
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()

--- a/inference/inference_api_test/python_api_test/tests/xpu/xpu_ttfnet_test.py
+++ b/inference/inference_api_test/python_api_test/tests/xpu/xpu_ttfnet_test.py
@@ -38,7 +38,7 @@ def inference_ttfnet(img, model_path, params_path):
     batch_size = 1
     config = Config(model_path, params_path)
     config.enable_xpu(10 * 1024 * 1024)
-    config.enable_lite_engine(PrecisionType.Float32, True) 
+    config.enable_lite_engine(PrecisionType.Float32, True)
     config.switch_ir_optim(True)
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
@@ -46,21 +46,21 @@ def inference_ttfnet(img, model_path, params_path):
 
     predictor = create_predictor(config)
     input_names = predictor.get_input_names()
-   # input_handle0 = predictor.get_input_handle(input_names[0])
-   # input_handle1 = predictor.get_input_handle(input_names[1])
-   # input_handle2 = predictor.get_input_handle(input_names[2])
+    # input_handle0 = predictor.get_input_handle(input_names[0])
+    # input_handle1 = predictor.get_input_handle(input_names[1])
+    # input_handle2 = predictor.get_input_handle(input_names[2])
 
     im_size = 512
     data = image_preprocess.preprocess(img, im_size)
     scale_factor = np.array([im_size * 1. / img.shape[0], im_size *
-                            1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
+                             1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
     im_shape = np.array([im_size, im_size]).reshape((1, 2)).astype(np.float32)
     data_input = [data, scale_factor]
 
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()
@@ -89,7 +89,7 @@ def test_ttfnet():
     test_model = test_gpu_model_jetson(model_name=model_name)
     model_path, params_path = test_model.test_comb_model_path(
         "cv_detect_model")
-    #with_lr_data = inference_yolov3_r50vd(model_path,params_path,ir_optim=True)
+    # with_lr_data = inference_yolov3_r50vd(model_path,params_path,ir_optim=True)
     img_name = 'kite.jpg'
     image_path = test_model.test_readdata(
         path="cv_detect_model", data_name=img_name)
@@ -99,4 +99,4 @@ def test_ttfnet():
     test_model.test_diff(npy_result, with_lr_data[0], diff_standard)
 
     # det image with box
-    #image_preprocess.draw_bbox(img_name, without_lr_data[0], save_name="ttfnet.jpg")
+    # image_preprocess.draw_bbox(img_name, without_lr_data[0], save_name="ttfnet.jpg")

--- a/inference/inference_api_test/python_api_test/tests/xpu/xpu_unet_test.py
+++ b/inference/inference_api_test/python_api_test/tests/xpu/xpu_unet_test.py
@@ -22,6 +22,7 @@ from paddle.inference import PrecisionType
 from paddle.inference import create_predictor
 from test_src import test_gpu_model_jetson
 
+
 def inference_unet(img, model_path, params_path):
     """
     inference_unet
@@ -35,7 +36,7 @@ def inference_unet(img, model_path, params_path):
     batch_size = 1
     config = Config(model_path, params_path)
     config.enable_xpu(10 * 1024 * 1024)
-    config.enable_lite_engine(PrecisionType.Float32, True) 
+    config.enable_lite_engine(PrecisionType.Float32, True)
     config.switch_ir_optim(True)
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
@@ -43,7 +44,7 @@ def inference_unet(img, model_path, params_path):
 
     mean = [0.5, 0.5, 0.5]
     std = [0.5, 0.5, 0.5]
-    data = image_preprocess.normalize(img,mean,std)
+    data = image_preprocess.normalize(img, mean, std)
     data_input = np.array([data]).transpose([0, 3, 1, 2])
 
     predictor = create_predictor(config)
@@ -60,6 +61,7 @@ def inference_unet(img, model_path, params_path):
     output_data = output_handle.copy_to_cpu()
 
     return output_data
+
 
 @pytest.mark.p0
 @pytest.mark.p1
@@ -82,7 +84,7 @@ def test_unet():
     with_lr_data = inference_unet(img, model_path, params_path)
     npy_result = test_model.npy_result_path("cv_seg_model")
     test_model.test_diff(npy_result, with_lr_data[0], diff_standard)
-    
+
     # save color img
     # np.save("unet.npy",with_lr_data[0]) 
     # imgs = np.argmax(with_lr_data[0], axis=0)

--- a/inference/inference_api_test/python_api_test/tests/xpu/xpu_yolov3_darknet53_test.py
+++ b/inference/inference_api_test/python_api_test/tests/xpu/xpu_yolov3_darknet53_test.py
@@ -37,7 +37,7 @@ def inference_yolov3_darknet53(img, model_path, params_path):
     batch_size = 1
     config = Config(model_path, params_path)
     config.enable_xpu(10 * 1024 * 1024)
-    config.enable_lite_engine(PrecisionType.Float32, True) 
+    config.enable_lite_engine(PrecisionType.Float32, True)
     config.switch_ir_optim(True)
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
@@ -49,14 +49,14 @@ def inference_yolov3_darknet53(img, model_path, params_path):
     im_size = 608
     data = image_preprocess.preprocess(img, im_size)
     scale_factor = np.array([im_size * 1. / img.shape[0], im_size *
-                            1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
+                             1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
     im_shape = np.array([im_size, im_size]).reshape((1, 2)).astype(np.float32)
     data_input = [im_shape, data, scale_factor]
 
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()
@@ -85,7 +85,7 @@ def test_yolov3_darknet53():
     test_model = test_gpu_model_jetson(model_name=model_name)
     model_path, params_path = test_model.test_comb_model_path(
         "cv_detect_model")
-    #with_lr_data = inference_yolov3_r50vd(model_path,params_path,ir_optim=True)
+    # with_lr_data = inference_yolov3_r50vd(model_path,params_path,ir_optim=True)
     img_name = 'kite.jpg'
     image_path = test_model.test_readdata(
         path="cv_detect_model", data_name=img_name)

--- a/inference/inference_api_test/python_api_test/tests/xpu/xpu_yolov3_mobilenet_v1_test.py
+++ b/inference/inference_api_test/python_api_test/tests/xpu/xpu_yolov3_mobilenet_v1_test.py
@@ -37,7 +37,7 @@ def inference_yolov3_mobilenet_v1(img, model_path, params_path):
     batch_size = 1
     config = Config(model_path, params_path)
     config.enable_xpu(10 * 1024 * 1024)
-    config.enable_lite_engine(PrecisionType.Float32, True) 
+    config.enable_lite_engine(PrecisionType.Float32, True)
     config.switch_ir_optim(True)
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
@@ -49,14 +49,14 @@ def inference_yolov3_mobilenet_v1(img, model_path, params_path):
     im_size = 608
     data = image_preprocess.preprocess(img, im_size)
     scale_factor = np.array([im_size * 1. / img.shape[0], im_size *
-                            1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
+                             1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
     im_shape = np.array([im_size, im_size]).reshape((1, 2)).astype(np.float32)
     data_input = [im_shape, data, scale_factor]
 
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()
@@ -85,7 +85,7 @@ def test_yolov3_mobilenet_v1():
     test_model = test_gpu_model_jetson(model_name=model_name)
     model_path, params_path = test_model.test_comb_model_path(
         "cv_detect_model")
-    #with_lr_data = inference_yolov3_mobilenet_v1(model_path,params_path,ir_optim=True)
+    # with_lr_data = inference_yolov3_mobilenet_v1(model_path,params_path,ir_optim=True)
     img_name = 'kite.jpg'
     image_path = test_model.test_readdata(
         path="cv_detect_model", data_name=img_name)

--- a/inference/inference_api_test/python_api_test/tests/xpu/xpu_yolov3_r50vd_test.py
+++ b/inference/inference_api_test/python_api_test/tests/xpu/xpu_yolov3_r50vd_test.py
@@ -37,7 +37,7 @@ def inference_yolov3_r50vd(img, model_path, params_path):
     batch_size = 1
     config = Config(model_path, params_path)
     config.enable_xpu(10 * 1024 * 1024)
-    config.enable_lite_engine(PrecisionType.Float32, True) 
+    config.enable_lite_engine(PrecisionType.Float32, True)
     config.switch_ir_optim(True)
     config.switch_use_feed_fetch_ops(False)
     config.switch_specify_input_names(True)
@@ -49,14 +49,14 @@ def inference_yolov3_r50vd(img, model_path, params_path):
     im_size = 608
     data = image_preprocess.preprocess(img, im_size)
     scale_factor = np.array([im_size * 1. / img.shape[0], im_size *
-                            1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
+                             1. / img.shape[1]]).reshape((1, 2)).astype(np.float32)
     im_shape = np.array([im_size, im_size]).reshape((1, 2)).astype(np.float32)
     data_input = [im_shape, data, scale_factor]
 
     for i, name in enumerate(input_names):
         input_tensor = predictor.get_input_handle(name)
         input_tensor.reshape(data_input[i].shape)
-        input_tensor.copy_from_cpu(data_input[i].copy())
+        input_tensor.copy_from_cpu(data_input[i])
 
     # do the inference
     predictor.run()
@@ -69,6 +69,7 @@ def inference_yolov3_r50vd(img, model_path, params_path):
         output_data = output_tensor.copy_to_cpu()
         results.append(output_data)
     return results
+
 
 @pytest.mark.p0
 def test_yolov3_r50vd():
@@ -84,7 +85,7 @@ def test_yolov3_r50vd():
     test_model = test_gpu_model_jetson(model_name=model_name)
     model_path, params_path = test_model.test_comb_model_path(
         "cv_detect_model")
-    #with_lr_data = inference_yolov3_r50vd(model_path,params_path,ir_optim=True)
+    # with_lr_data = inference_yolov3_r50vd(model_path,params_path,ir_optim=True)
     img_name = 'kite.jpg'
     image_path = test_model.test_readdata(
         path="cv_detect_model", data_name=img_name)
@@ -92,7 +93,7 @@ def test_yolov3_r50vd():
     with_lr_data = inference_yolov3_r50vd(img, model_path, params_path)
     npy_result = test_model.npy_result_path("cv_detect_model")
     test_model.test_diff(npy_result, with_lr_data[0], diff_standard)
-    
+
     # det image with box
     # np.save("yolov3_r50vd.npy",with_lr_data[0])
     # image_preprocess.draw_bbox(


### PR DESCRIPTION
Remove the .copy() of copy_from_cpu after the pybind bug when copy_from_cpu accepts input from a float, it will call the overload of double, which is fixed in [pr52225](https://github.com/PaddlePaddle/Paddle/pull/52225)