### PR TITLE
update -std=c++11 to -std=c++14

### DIFF
--- a/inference/inference_api_test/cpp_api_test/src/CMakeLists.txt
+++ b/inference/inference_api_test/cpp_api_test/src/CMakeLists.txt
@@ -47,7 +47,7 @@ link_directories("${PADDLE_LIB_THIRD_PARTY_PATH}onnxruntime/lib")
 link_directories("${PADDLE_LIB}/paddle/lib")
 
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0 -std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0 -std=c++14")
 message("flags" ${CMAKE_CXX_FLAGS})
 
 if (USE_TENSORRT AND WITH_GPU)

--- a/inference/inference_api_test/cpp_api_test/src/test_bert.cc
+++ b/inference/inference_api_test/cpp_api_test/src/test_bert.cc
@@ -27,6 +27,8 @@
 #include "test_helper.h"
 #include "bert_test_helper.h"
 
+DEFINE_int32(paddle_num_threads, 1, "Number of threads for CPU inference");
+
 namespace paddle {
 namespace test {
 void SetConfig(AnalysisConfig *config) {

--- a/inference/inference_api_test/cpp_api_test/src/test_multi_thread.cc
+++ b/inference/inference_api_test/cpp_api_test/src/test_multi_thread.cc
@@ -25,7 +25,7 @@
 
 #include "test_helper.h" //NOLINT
 
-DEFINE_int32(paddle_num_threads, 1, "Number of threads for CPU inference")
+DEFINE_int32(paddle_num_threads, 1, "Number of threads for CPU inference");
 
 namespace paddle {
 namespace test {

--- a/inference/inference_api_test/cpp_api_test/src/test_multi_thread.cc
+++ b/inference/inference_api_test/cpp_api_test/src/test_multi_thread.cc
@@ -25,6 +25,8 @@
 
 #include "test_helper.h" //NOLINT
 
+DEFINE_int32(paddle_num_threads, 1, "Number of threads for CPU inference")
+
 namespace paddle {
 namespace test {
 

--- a/inference/inference_api_test/cpp_api_test/src/test_ocr.cc
+++ b/inference/inference_api_test/cpp_api_test/src/test_ocr.cc
@@ -16,7 +16,10 @@
 #include <fstream>
 
 #include <gtest/gtest.h>
+#include <gflags/gflags.h>
 #include "test_helper.h"
+
+DEFINE_int32(paddle_num_threads, 1, "Number of threads for CPU inference");
 
 namespace paddle {
 namespace test {

--- a/inference/inference_api_test/cpp_api_test/src/test_resnet50.cc
+++ b/inference/inference_api_test/cpp_api_test/src/test_resnet50.cc
@@ -17,8 +17,10 @@
 
 #include "gtest/gtest.h"
 #include "test_helper.h" //NOLINT
+#include <gflags/gflags.h>
 
 DEFINE_bool(disable_mkldnn_fc, false, "Disable usage of MKL-DNN's FC op");
+DEFINE_int32(paddle_num_threads, 1, "Number of threads for CPU inference");
 
 namespace paddle {
 namespace test {


### PR DESCRIPTION
1. update -std=c++11 to -std=c++14 ref to [#50445](https://github.com/PaddlePaddle/Paddle/pull/50445)
2. set DEFINE_int32(paddle_num_threads, 1, "Number of threads for CPU inference") to solve the error of ‘FLAGS_paddle_num_threads’ was not declared in this scope