### PR TITLE
Fix libcommon not found

### DIFF
--- a/inference/inference_api_test/cpp_api_test/src/CMakeLists.txt
+++ b/inference/inference_api_test/cpp_api_test/src/CMakeLists.txt
@@ -84,6 +84,8 @@ else()
   set(DEPS ${PADDLE_LIB}/paddle/lib/libpaddle_inference${CMAKE_SHARED_LIBRARY_SUFFIX})
 endif()
 
+set(DEPS ${PADDLE_LIB}/paddle/lib/libcommon${CMAKE_SHARED_LIBRARY_SUFFIX})
+
 set(EXTERNAL_LIB "-lrt -ldl -lpthread -lprotobuf")
 set(DEPS ${DEPS}
   ${MATH_LIB} ${MKLDNN_LIB} ${NGRAPH_LIB}


### PR DESCRIPTION
修复：libcommon.so, needed by paddle_inference_install_dir/paddle/lib/libpaddle_inference.so, not found