### PR TITLE
Revert "Fix libcommon not found (#289)"

### DIFF
--- a/inference/inference_api_test/cpp_api_test/src/CMakeLists.txt
+++ b/inference/inference_api_test/cpp_api_test/src/CMakeLists.txt
@@ -84,8 +84,6 @@ else()
   set(DEPS ${PADDLE_LIB}/paddle/lib/libpaddle_inference${CMAKE_SHARED_LIBRARY_SUFFIX})
 endif()
 
-set(DEPS ${PADDLE_LIB}/paddle/lib/libcommon${CMAKE_SHARED_LIBRARY_SUFFIX})
-
 set(EXTERNAL_LIB "-lrt -ldl -lpthread -lprotobuf")
 set(DEPS ${DEPS}
   ${MATH_LIB} ${MKLDNN_LIB} ${NGRAPH_LIB}


### PR DESCRIPTION
This reverts commit 205248c931150611dc86268abdb132d0ac59aace.